### PR TITLE
Unify Event Systems (upgrade Items & Spells Event Systems), introduce technical improvements, fixes & changes

### DIFF
--- a/src/app/core/heroes/humans/helvetica.ts
+++ b/src/app/core/heroes/humans/helvetica.ts
@@ -3,7 +3,6 @@ import { ItemWindCrest } from '../../items/neutral';
 import { HasteSpell, RainOfFireSpell } from '../../spells/common';
 import { heroDescrElem } from '../../ui';
 import { HeroBase } from '../types';
-import { heroesDefaultResources } from '../utils';
 
 export const HelveticaHero: HeroBase = humansFraction.createHero({
   name: 'Helvetica',
@@ -27,7 +26,9 @@ export const HelveticaHero: HeroBase = humansFraction.createHero({
   }],
   items: [ItemWindCrest],
   resources: {
-    ...heroesDefaultResources,
+    gems: 0,
+    gold: 750,
+    redCrystals: 0,
     wood: 4,
   },
   stats: {

--- a/src/app/core/items/index.ts
+++ b/src/app/core/items/index.ts
@@ -1,2 +1,3 @@
 export * from './types';
+export * from './item-events';
 export * from './inventory';

--- a/src/app/core/items/inventory.ts
+++ b/src/app/core/items/inventory.ts
@@ -1,6 +1,5 @@
 import { ItemInstanceModel, ItemSlotType } from "./types";
 
-
 export interface ExtendedSlotType {
   icon: string;
   name: string;

--- a/src/app/core/items/item-events.ts
+++ b/src/app/core/items/item-events.ts
@@ -1,0 +1,25 @@
+import { createEventType } from 'src/app/store';
+import { createEventsGroup } from 'src/app/store/events/event-groups';
+
+export const itemEvents = {
+  NewRoundBegins: createEventType<{ round: number }>(''),
+};
+
+// it feels like hybrid approach can be used.
+// events object above can be used for easy use
+// and refactoring, while events group can
+// prepare events for logging, give ability to
+// get item event by name, etc.
+export const ItemsEvents = createEventsGroup({
+  prefix: 'Items',
+  events: itemEvents,
+});
+
+// change later
+export type ItemEventTypes = keyof typeof itemEvents;
+
+export type ItemsEventsHandlers = { [K in keyof typeof itemEvents]?: (target: ReturnType<(typeof itemEvents)[K]>) => void };
+
+export interface ItemsEventsRef {
+  on: (handlers: ItemsEventsHandlers) => void;
+}

--- a/src/app/core/items/neutral/eclipse-wand.ts
+++ b/src/app/core/items/neutral/eclipse-wand.ts
@@ -1,6 +1,6 @@
 import { EnchantBuff } from '../../spells/common';
 import { spellDescrElem } from '../../ui';
-import { ItemBaseModel, GameEventTypes, ItemSlotType } from '../types';
+import { ItemBaseModel, ItemSlotType } from '../types';
 
 export const ItemEclipseWand: ItemBaseModel<{}> = {
   name: 'Eclipse Wand',
@@ -22,7 +22,7 @@ export const ItemEclipseWand: ItemBaseModel<{}> = {
     init: ({ actions, events, ownerPlayer }) => {
 
       events.on({
-        [GameEventTypes.NewRoundBegins]: event => {
+        NewRoundBegins(event) {
           if (event.round === 0) {
             const enemyPlayer = actions.getEnemyPlayer();
             const enemyUnitGroups = actions.getUnitGroupsOfPlayer(enemyPlayer);

--- a/src/app/core/items/neutral/wind-crest.ts
+++ b/src/app/core/items/neutral/wind-crest.ts
@@ -1,4 +1,4 @@
-import { GameEventTypes, ItemBaseModel, ItemSlotType } from '..';
+import { ItemBaseModel, ItemSlotType } from '..';
 import { WindBlessBuff } from '../../spells/common';
 import { itemStatsDescr, spellDescrElem } from '../../ui';
 
@@ -25,7 +25,7 @@ export const ItemWindCrest: ItemBaseModel = {
       actions, events, ownerPlayer,
     }) => {
       events.on({
-        [GameEventTypes.NewRoundBegins]: event => {
+        NewRoundBegins(event) {
           if (event.round === 0) {
             actions.getUnitGroupsOfPlayer(ownerPlayer)
               .filter(unitGroup => unitGroup.type.defaultModifiers?.isRanged)

--- a/src/app/core/items/types.ts
+++ b/src/app/core/items/types.ts
@@ -26,30 +26,13 @@ import { PlayerInstanceModel } from '../players';
 import { SpellModel } from '../spells';
 import { DescriptionElement } from '../ui';
 import { Modifiers, UnitGroupModel } from '../unit-types';
+import { ItemsEventsRef } from './item-events';
 
 
 export interface ItemRequirementModel<T extends object> {
   type: string;
   value?: number | string | boolean;
   isRequirementMet?: (item: ItemBaseModel<T>, unitGroup: UnitGroupModel) => boolean;
-}
-
-export enum GameEventTypes {
-  NewRoundBegins,
-}
-
-export interface GameEventNewRoundBegins {
-  round: number;
-}
-
-export interface GameEventsMapping {
-  [GameEventTypes.NewRoundBegins]: GameEventNewRoundBegins;
-}
-
-export type GameEventsHandlers = { [K in keyof GameEventsMapping]?: (target: GameEventsMapping[K]) => void };
-
-export interface GameEventsRef {
-  on: (handlers: GameEventsHandlers) => void;
 }
 
 
@@ -88,7 +71,7 @@ export interface ItemBaseModel<StateType extends object = object> {
   config: {
     init: (combatRefs: {
       actions: CombatActionsRef,
-      events: GameEventsRef,
+      events: ItemsEventsRef,
       ownerPlayer: PlayerInstanceModel,
       ownerHero: Hero,
       thisInstance: ItemInstanceModel<StateType>,

--- a/src/app/core/spells/common/corrosive-fog.ts
+++ b/src/app/core/spells/common/corrosive-fog.ts
@@ -1,7 +1,6 @@
 import { EffectAnimation } from '../../api/vfx-api';
 import { spellDescrElem, strPercent } from '../../ui';
 import { createAnimation, getIconElement, getPlainBlurFrames, getReversePulseKeyframes } from '../../vfx';
-import { SpellEventTypes } from '../spell-events';
 import { SpellActivationType, SpellModel } from '../types';
 import { canActivateOnEnemyFn, debuffColors } from '../utils';
 
@@ -99,7 +98,7 @@ export const CorrosiveFogDebuff: SpellModel<undefined | { debuffRoundsLeft: numb
       },
       init({ events, actions, thisSpell, spellInstance, vfx }) {
         events.on({
-          [SpellEventTypes.SpellPlacedOnUnitGroup]: ({ target }) => {
+          SpellPlacedOnUnitGroup({ target }) {
             const debuffData = {
               debuffRoundsLeft: roundsDuration,
             };
@@ -117,7 +116,7 @@ export const CorrosiveFogDebuff: SpellModel<undefined | { debuffRoundsLeft: numb
             actions.historyLog(`${target.type.name} gets negative effect "${thisSpell.name}"`);
 
             events.on({
-              [SpellEventTypes.NewRoundBegins]: (event) => {
+              NewRoundBegins(event) {
                 debuffData.debuffRoundsLeft--;
 
                 if (!debuffData.debuffRoundsLeft) {
@@ -168,7 +167,7 @@ export const CorrosiveFogSpell: SpellModel = {
 
       init({ events, actions, ownerPlayer, ownerHero, thisSpell }) {
         events.on({
-          [SpellEventTypes.PlayerTargetsSpell]: event => {
+          PlayerTargetsSpell(event) {
             actions.historyLog(`${ownerHero.name} casts "${thisSpell.name}" against ${event.target.type.name}`);
 
             const poisonDebuffInstance = actions.createSpellInstance(CorrosiveFogDebuff);

--- a/src/app/core/spells/common/enchant.ts
+++ b/src/app/core/spells/common/enchant.ts
@@ -1,8 +1,7 @@
 import { spellDescrElem } from '../../ui';
 import { EnchantAnimation } from '../../vfx';
-import { SpellEventTypes } from '../spell-events';
-import { SpellModel, SpellActivationType } from '../types';
-import { debuffColors, canActivateOnEnemyFn } from '../utils';
+import { SpellActivationType, SpellModel } from '../types';
+import { canActivateOnEnemyFn, debuffColors } from '../utils';
 
 const damageIncreasePercent = 17;
 
@@ -35,7 +34,7 @@ export const EnchantBuff: SpellModel = {
         });
 
         events.on({
-          [SpellEventTypes.SpellPlacedOnUnitGroup]: (event) => {
+          SpellPlacedOnUnitGroup(event) {
             vfx.createEffectForUnitGroup(event.target, EnchantAnimation, { duration: 1000 });
             actions.addModifiersToUnitGroup(event.target, mods);
           },
@@ -79,7 +78,7 @@ export const EnchantSpell: SpellModel = {
 
       init: ({ events, actions, ownerPlayer }) => {
         events.on({
-          [SpellEventTypes.PlayerTargetsSpell]: (event) => {
+          PlayerTargetsSpell(event) {
             const enchantDebuff = actions.createSpellInstance(EnchantBuff);
             actions.addSpellToUnitGroup(event.target, enchantDebuff, ownerPlayer);
             actions.historyLog('Enemy is enchanted');

--- a/src/app/core/spells/common/firebird-heal.ts
+++ b/src/app/core/spells/common/firebird-heal.ts
@@ -1,7 +1,6 @@
 import { EffectAnimation } from '../../api/vfx-api';
 import { spellDescrElem } from '../../ui';
 import { createAnimation, getHealParts, getIconElement, getPlainAppearanceFrames, getPlainBlurFrames, getReversePulseKeyframes } from '../../vfx';
-import { SpellEventTypes } from '../spell-events';
 import { SpellActivationType, SpellModel } from '../types';
 import { canActivateOnAllyFn } from '../utils';
 
@@ -88,7 +87,7 @@ export const FirebirdHealSpell: SpellModel = {
       },
       init: ({ events, actions, ownerUnit, vfx }) => {
         events.on({
-          [SpellEventTypes.PlayerTargetsSpell]: (event) => {
+          PlayerTargetsSpell(event) {
             const casterUnit = ownerUnit!;
 
             const healValue = casterUnit.count * healPerBird;

--- a/src/app/core/spells/common/fright.ts
+++ b/src/app/core/spells/common/fright.ts
@@ -1,8 +1,7 @@
 import { spellDescrElem } from '../../ui';
 import { UnitGroupInstModel } from '../../unit-types';
 import { FrightAnimation } from '../../vfx';
-import { SpellEventTypes } from '../spell-events';
-import { SpellModel, SpellActivationType } from '../types';
+import { SpellActivationType, SpellModel } from '../types';
 import { debuffColors } from '../utils';
 
 const damageDecreasePercent = 0.25;
@@ -29,7 +28,7 @@ export const FrightSpellDebuff: SpellModel<{ frighter: UnitGroupInstModel }> = {
     spellConfig: {
       init({ actions, events, spellInstance, vfx }) {
         events.on({
-          [SpellEventTypes.SpellPlacedOnUnitGroup]({ target }) {
+          SpellPlacedOnUnitGroup({ target }) {
             const reducedDamageCMod = actions.createModifiers({
               attackConditionalModifiers(params) {
                 if (params.attacked === spellInstance.state?.frighter) {
@@ -75,7 +74,7 @@ export const FrightSpell: SpellModel = {
     spellConfig: {
       init({ actions, events, ownerPlayer, ownerUnit }) {
         events.on({
-          [SpellEventTypes.UnitGroupAttacks]({ attacked, attacker }) {
+          UnitGroupAttacks({ attacked, attacker }) {
             if (ownerUnit !== attacker) {
               return;
             }

--- a/src/app/core/spells/common/frost-arrow.ts
+++ b/src/app/core/spells/common/frost-arrow.ts
@@ -1,10 +1,9 @@
 import { DamageType } from '../../api/combat-api';
 import { EffectAnimation } from '../../api/vfx-api';
 import { spellDescrElem } from '../../ui';
-import { createAnimation, getIconElement, getPlainAppearanceFrames, getPlainBlurFrames, getReversePulseKeyframes, getDamageParts } from '../../vfx';
-import { SpellEventTypes } from '../spell-events';
-import { SpellModel, SpellActivationType } from '../types';
-import { debuffColors, canActivateOnEnemyFn } from '../utils';
+import { createAnimation, getDamageParts, getIconElement, getPlainAppearanceFrames, getPlainBlurFrames, getReversePulseKeyframes } from '../../vfx';
+import { SpellActivationType, SpellModel } from '../types';
+import { canActivateOnEnemyFn, debuffColors } from '../utils';
 
 const icon = 'frost-emblem';
 
@@ -79,7 +78,7 @@ export const FrozenArrowDebuff: SpellModel = {
         });
 
         events.on({
-          [SpellEventTypes.SpellPlacedOnUnitGroup]: ({ target }) => {
+          SpellPlacedOnUnitGroup({ target }) {
             vfx.createEffectForUnitGroup(target, FrozenAnimation, { duration: 800 });
             actions.addModifiersToUnitGroup(target, mods);
             actions.historyLog(`${target.type.name} receives ${thisSpell.name} debuff, slowed by ${slow} and gains -${attackPenalty} attack rating penalty.`);
@@ -124,7 +123,7 @@ export const FrostArrowSpell: SpellModel = {
 
       init: ({ events, actions, ownerPlayer, ownerHero, thisSpell, vfx }) => {
         events.on({
-          [SpellEventTypes.PlayerTargetsSpell]: (event) => {
+          PlayerTargetsSpell: (event) => {
             const enchantDebuff = actions.createSpellInstance(FrozenArrowDebuff);
             // not sure about ownerPlayer
             actions.addSpellToUnitGroup(event.target, enchantDebuff, ownerPlayer);

--- a/src/app/core/spells/common/haste.ts
+++ b/src/app/core/spells/common/haste.ts
@@ -1,7 +1,6 @@
 import { EffectAnimation } from '../../api/vfx-api';
 import { spellDescrElem } from '../../ui';
 import { createAnimation, getIconElement, getPlainAppearanceFrames, getPlainBlurFrames, getReversePulseKeyframes } from '../../vfx';
-import { SpellEventTypes } from '../spell-events';
 import { SpellActivationType, SpellModel } from '../types';
 import { buffColors, canActivateOnAllyFn } from '../utils';
 
@@ -75,7 +74,7 @@ export const HasteBuff: SpellModel = {
         });
 
         events.on({
-          [SpellEventTypes.SpellPlacedOnUnitGroup]: (event) => {
+          SpellPlacedOnUnitGroup(event) {
             vfx.createEffectForUnitGroup(event.target, HasteAnimation, { duration: 800 });
             actions.addModifiersToUnitGroup(event.target, mods);
           },
@@ -119,7 +118,7 @@ export const HasteSpell: SpellModel = {
 
       init: ({ events, actions, ownerPlayer }) => {
         events.on({
-          [SpellEventTypes.PlayerTargetsSpell]: (event) => {
+          PlayerTargetsSpell(event) {
             const enchantDebuff = actions.createSpellInstance(HasteBuff);
             actions.addSpellToUnitGroup(event.target, enchantDebuff, ownerPlayer);
           },

--- a/src/app/core/spells/common/heal.ts
+++ b/src/app/core/spells/common/heal.ts
@@ -1,6 +1,5 @@
 import { EffectAnimation } from '../../api/vfx-api';
 import { createAnimation, getHealParts, getIconElement, getPlainAppearanceFrames, getPlainBlurFrames, getReversePulseKeyframes } from '../../vfx';
-import { SpellEventTypes } from '../spell-events';
 import { SpellActivationType, SpellModel } from '../types';
 import { canActivateOnAllyFn } from '../utils';
 
@@ -75,7 +74,7 @@ export const HealSpell: SpellModel = {
 
       init: ({ events, actions, ownerPlayer, ownerUnit, vfx }) => {
         events.on({
-          [SpellEventTypes.PlayerTargetsSpell]: (event) => {
+          PlayerTargetsSpell(event) {
 
             const healValue = 64;
             const originalCount = event.target.count;

--- a/src/app/core/spells/common/kneeling-light.ts
+++ b/src/app/core/spells/common/kneeling-light.ts
@@ -1,5 +1,4 @@
 import { spellDescrElem } from '../../ui';
-import { SpellEventTypes } from '../spell-events';
 import { SpellActivationType, SpellModel } from '../types';
 import { canActivateOnEnemyFn, debuffColors } from '../utils';
 
@@ -34,7 +33,7 @@ export const KneelingLightDebuff: SpellModel = {
         });
 
         events.on({
-          [SpellEventTypes.SpellPlacedOnUnitGroup]: (event) => {
+          SpellPlacedOnUnitGroup(event) {
             // vfx.createEffectForUnitGroup(event.target, EnchantAnimation, { duration: 1000 });
             actions.addModifiersToUnitGroup(event.target, mods);
           },
@@ -81,7 +80,7 @@ export const KneelingLight: SpellModel = {
 
       init: ({ events, actions, ownerPlayer }) => {
         events.on({
-          [SpellEventTypes.PlayerTargetsSpell]: (event) => {
+          PlayerTargetsSpell(event) {
             const enchantDebuff = actions.createSpellInstance(KneelingLightDebuff);
             actions.addSpellToUnitGroup(event.target, enchantDebuff, ownerPlayer);
           },

--- a/src/app/core/spells/common/meteor.ts
+++ b/src/app/core/spells/common/meteor.ts
@@ -2,7 +2,6 @@ import { DamageType } from '../../api/combat-api';
 import { spellDescrElem } from '../../ui';
 import { CommonUtils } from '../../unit-types';
 import { createFireAnimation, getDamageParts } from '../../vfx';
-import { SpellEventTypes } from '../spell-events';
 import { SpellActivationType, SpellModel } from '../types';
 
 const minDamage = 82;
@@ -39,7 +38,7 @@ export const MeteorSpell: SpellModel = {
 
       init({ events, actions, thisSpell, ownerHero, vfx }) {
         events.on({
-          [SpellEventTypes.PlayerCastsInstantSpell]: event => {
+          PlayerCastsInstantSpell(event) {
             const randomEnemyGroup = actions.getRandomEnemyPlayerGroup();
 
             const countBeforeDamage = randomEnemyGroup.count;

--- a/src/app/core/spells/common/poison-cloud.ts
+++ b/src/app/core/spells/common/poison-cloud.ts
@@ -3,7 +3,6 @@ import { EffectAnimation } from '../../api/vfx-api';
 import { spellDescrElem } from '../../ui';
 import { CommonUtils } from '../../unit-types';
 import { createAnimation, getDamageParts, getIconElement, getPlainBlurFrames, getReversePulseKeyframes } from '../../vfx';
-import { SpellEventTypes } from '../spell-events';
 import { SpellActivationType, SpellModel } from '../types';
 import { canActivateOnEnemyFn, debuffColors } from '../utils';
 
@@ -105,7 +104,7 @@ export const PoisonCloudDebuff: SpellModel<undefined | { debuffRoundsLeft: numbe
       },
       init({ events, actions, thisSpell, spellInstance, vfx }) {
         events.on({
-          [SpellEventTypes.SpellPlacedOnUnitGroup]: ({ target }) => {
+          SpellPlacedOnUnitGroup({ target }) {
             const debuffData = {
               debuffRoundsLeft: roundsDuration,
             };
@@ -122,7 +121,7 @@ export const PoisonCloudDebuff: SpellModel<undefined | { debuffRoundsLeft: numbe
             actions.historyLog(`${target.type.name} gets negative effect "${thisSpell.name}"`);
 
             events.on({
-              [SpellEventTypes.NewRoundBegins]: (event) => {
+              NewRoundBegins(event) {
 
                 actions.dealDamageTo(target, CommonUtils.randIntInRange(minDamage, maxDamage), DamageType.Magic, (damageInfo) => {
                   actions.historyLog(`Poison deals ${damageInfo.finalDamage} damage to ${target.type.name}, ${damageInfo.unitLoss} units perish`);
@@ -186,7 +185,7 @@ export const PoisonCloudSpell: SpellModel = {
 
       init({ events, actions, ownerPlayer, ownerHero, thisSpell }) {
         events.on({
-          [SpellEventTypes.PlayerTargetsSpell]: event => {
+          PlayerTargetsSpell(event) {
             actions.historyLog(`${ownerHero.name} casts "${thisSpell.name}" against ${event.target.type.name}`);
 
             const poisonDebuffInstance = actions.createSpellInstance(PoisonCloudDebuff);

--- a/src/app/core/spells/common/rain-of-fire.ts
+++ b/src/app/core/spells/common/rain-of-fire.ts
@@ -1,7 +1,6 @@
 import { DamageType } from '../../api/combat-api';
 import { spellDescrElem } from '../../ui';
 import { FireAnimation, getDamageParts } from '../../vfx';
-import { SpellEventTypes } from '../spell-events';
 import { SpellActivationType, SpellModel } from '../types';
 import { canActivateOnEnemyFn } from '../utils';
 
@@ -31,7 +30,7 @@ export const RainOfFireSpell: SpellModel = {
       init: ({ events, actions, thisSpell, ownerHero, vfx }) => {
 
         events.on({
-          [SpellEventTypes.PlayerTargetsSpell]: (event) => {
+          PlayerTargetsSpell(event) {
 
             vfx.createEffectForUnitGroup(event.target, FireAnimation, {
               duration: 850,

--- a/src/app/core/spells/common/summon-fire-spirits.ts
+++ b/src/app/core/spells/common/summon-fire-spirits.ts
@@ -1,10 +1,7 @@
-import { DamageType } from '../../api/combat-api';
 import { neutralsFraction } from '../../fractions/neutrals/fraction';
 import { spellDescrElem } from '../../ui';
 import { FireAnimation } from '../../vfx';
-import { SpellEventTypes } from '../spell-events';
 import { SpellActivationType, SpellModel } from '../types';
-import { logDamage } from '../utils';
 
 export const SummonFireSpiritsSpell: SpellModel = {
   name: 'Summon Fire Spirits',
@@ -24,7 +21,7 @@ export const SummonFireSpiritsSpell: SpellModel = {
       getManaCost() { return 3; },
       init({ actions, ownerHero, ownerPlayer, events, vfx, thisSpell }) {
         events.on({
-          [SpellEventTypes.PlayerCastsInstantSpell]: () => {
+          PlayerCastsInstantSpell() {
             const summonedUnitGroup = actions.summonUnitsForPlayer(ownerPlayer, neutralsFraction.getUnitType('FireSpirits'), 4);
 
             vfx.createEffectForUnitGroup(summonedUnitGroup, FireAnimation, { duration: 1000 });

--- a/src/app/core/spells/common/wind-bless.ts
+++ b/src/app/core/spells/common/wind-bless.ts
@@ -1,7 +1,6 @@
 import { Colors } from '../../assets';
 import { spellPlainDescription } from '../../ui';
 import { Modifiers, UnitGroupInstModel } from '../../unit-types';
-import { SpellEventTypes } from '../spell-events';
 import { SpellActivationType, SpellModel } from '../types';
 
 type State = {
@@ -31,7 +30,7 @@ export const WindBlessBuff: SpellModel<State> = {
     spellConfig: {
       init: ({ events, actions, spellInstance }) => {
         events.on({
-          [SpellEventTypes.SpellPlacedOnUnitGroup]: (event) => {
+          SpellPlacedOnUnitGroup(event) {
             const mods = actions.createModifiers({
               unitGroupBonusAttack: attackBonus,
             });
@@ -45,7 +44,7 @@ export const WindBlessBuff: SpellModel<State> = {
 
             actions.addModifiersToUnitGroup(event.target, mods);
           },
-          [SpellEventTypes.NewRoundBegins]: (event) => {
+          NewRoundBegins(event) {
             const state = spellInstance.state as State;
 
             if (!(--state.roundsLeft)) {

--- a/src/app/core/spells/spell-events.ts
+++ b/src/app/core/spells/spell-events.ts
@@ -1,35 +1,51 @@
+import { createEventType } from 'src/app/store';
+import { createEventsGroup } from 'src/app/store/events/event-groups';
 import { PlayerInstanceModel } from '../players';
 import { UnitGroupInstModel } from '../unit-types';
 import { SpellInstance } from './types';
 
-export enum SpellEventTypes {
-  PlayerTargetsSpell,
-  PlayerCastsInstantSpell,
-  UnitGroupAttacks,
-  SpellPlacedOnUnitGroup,
-  NewRoundBegins,
-}
+export const spellEvents = {
+  PlayerTargetsSpell: createEventType<{ target: UnitGroupInstModel }>(''),
+  SpellPlacedOnUnitGroup: createEventType<{ target: UnitGroupInstModel }>(''),
+  NewRoundBegins: createEventType<{ round: number }>(''),
+  PlayerCastsInstantSpell: createEventType<{ player: PlayerInstanceModel, spell: SpellInstance }>(''),
+  UnitGroupAttacks: createEventType<{
+    attacker: UnitGroupInstModel;
+    attacked: UnitGroupInstModel;
+  }>(''),
+};
 
-export interface TargetSelected {
-  target: UnitGroupInstModel;
-}
+export const SpellEvents = createEventsGroup({
+  prefix: 'Spells',
+  events: spellEvents,
+});
 
-export interface NewRoundBegins {
-  round: number;
-}
 
-export interface UnitGroupAttacks {
-  attacker: UnitGroupInstModel;
-  attacked: UnitGroupInstModel;
-}
+// generalize it
+export type SpellEventTypes = keyof typeof spellEvents;
+export type SpellEvents = typeof spellEvents[SpellEventTypes];
 
-export interface SpellEventsMapping {
-  [SpellEventTypes.PlayerTargetsSpell]: TargetSelected;
-  [SpellEventTypes.SpellPlacedOnUnitGroup]: TargetSelected;
-  [SpellEventTypes.NewRoundBegins]: NewRoundBegins;
-  [SpellEventTypes.UnitGroupAttacks]: UnitGroupAttacks;
-  [SpellEventTypes.PlayerCastsInstantSpell]: { player: PlayerInstanceModel, spell: SpellInstance };
-}
+export type SpellEventType<K extends SpellEventTypes> = ReturnType<typeof spellEvents[K]>;
 
-export type SpellEventHandlers = { [K in keyof SpellEventsMapping]?: (target: SpellEventsMapping[K]) => void };
+export type SpellEventHandlers = { [K in SpellEventTypes]?: (target: ReturnType<typeof spellEvents[K]>) => void };
 
+
+// batch creation? grouped events? is it going to be useful? Gonna have to consider a couple of things
+// at very least.
+
+// gonna need to think how places in code are going to look
+//  it feels like all events are going to be used with prefix of the group.
+//  although, there can be a helper type straight from store folder, and it can actually
+//  work to use strings/enums, because here we are going to store both strings/Events regardless
+
+//  so, there will be 2 ways to work with groupedEvents, by group and string keys of this group
+//   strings look the simplest, and gonna need to see if they are going to be refactorable,
+//   although I'm not very sure about strings in terms of memory usage, since
+//   there is no string pool in js
+
+// There is at least one advantage: if I'm ever going to implement logging, by creating grouped events
+//   I will be able to reuse their key in logs, this way descriptions won't be so crucial, and
+//    can play a descriptive role even per case.
+
+// anyways, I think I need to give it a shot. It is going to take some time to implement
+//  and think through, and might be even discarded in the end (but looks interesting and promising)

--- a/src/app/core/triggers/index.ts
+++ b/src/app/core/triggers/index.ts
@@ -2,3 +2,4 @@ export * from './events';
 export * from './scripts/map-preparation';
 export * from './types';
 export * from './registry';
+export * from './ref-registry';

--- a/src/app/core/triggers/ref-registry.ts
+++ b/src/app/core/triggers/ref-registry.ts
@@ -1,0 +1,60 @@
+import { EventInfo, EventType } from 'src/app/store';
+
+// this is going to replace { Spell/Item: { Event: Handler } } and some other possible things in the future.
+export class RefEventTriggersRegistry<T> {
+  // theoretically, handlers can be in a Set instead of array, but not sure yet.
+  private triggerMapsByRefsMap: Map<T, Map<EventType, ((data: unknown) => void)[]>> = new Map();
+
+  public registerHandlerByRef<D extends object>(ref: T, event: EventType<D>, handler: (data: D) => void) {
+    const refTriggersMap = this.triggerMapsByRefsMap.get(ref);
+
+    if (refTriggersMap) {
+      const triggers = refTriggersMap.get(event as any);
+
+      if (triggers) {
+        triggers.push(handler as any);
+      } else {
+        refTriggersMap.set(event as any, [handler as any]);
+      }
+    } else {
+      this.triggerMapsByRefsMap.set(ref, new Map([[event as any, [handler as any]]]));
+    }
+  }
+
+  public triggerAllHandlersByEvent(event: EventInfo): void {
+    this.triggerMapsByRefsMap.forEach((refTriggersMap) => {
+      refTriggersMap.forEach((triggers, eventType) => triggers.forEach(trigger => {
+        if (eventType === event.__type) {
+          trigger(event);
+        }
+      }));
+    });
+  }
+
+  public triggerRefEventHandlers(ref: T, event: EventInfo): void {
+    const refTriggersMap = this.triggerMapsByRefsMap.get(ref);
+
+    if (refTriggersMap) {
+      refTriggersMap.forEach((triggers, eventType) => {
+        triggers.forEach(trigger => {
+          if (eventType === event.__type) {
+            trigger(event);
+          }
+        });
+      })
+    }
+  }
+
+  public removeAllHandlersForRef(ref: T): void {
+    this.triggerMapsByRefsMap.delete(ref);
+  }
+
+  public removeAllHandlers(): void {
+    this.triggerMapsByRefsMap.clear();
+  }
+}
+
+// const spellsRegistry = new RefEventTriggersRegistry();
+// spellsRegistry.registerHandlerByRef({}, spellEvents.NewRoundBegins, (data) => { console.log(data.round) })
+// spellsRegistry.triggerAllHandlersByEvent(spellEvents.NewRoundBegins({ round: 1 }));
+// spellsRegistry.triggerHandlersForRef({}, spellEvents.NewRoundBegins({ round: 1 }));

--- a/src/app/features/services/controllers/battle.service.ts
+++ b/src/app/features/services/controllers/battle.service.ts
@@ -2,11 +2,12 @@ import { Injectable } from '@angular/core';
 import { PlayerTypeEnum } from 'src/app/core/players';
 import { NeutralCampStructure } from 'src/app/core/structures';
 import { Notify, StoreClient, WireMethod } from 'src/app/store';
-import { FightEnds, FightNextRoundStarts, FightStarts, GroupDamagedByGroup, GroupDamagedByGroupEvent, GroupDies, GroupSpeedChanged, GroupTakesDamage, GroupTakesDamageEvent, PlayerTurnStartEvent, RoundGroupSpendsTurn, RoundGroupSpendsTurnEvent, RoundGroupTurnEnds, RoundPlayerCountinuesAttacking, RoundPlayerTurnStarts, UnitHealed, UnitHealedEvent } from '../events';
+import { CleanUpHandlersOnFightEnd, FightEnds, FightNextRoundStarts, FightStarts, GroupDamagedByGroup, GroupDamagedByGroupEvent, GroupDies, GroupSpeedChanged, GroupTakesDamage, GroupTakesDamageEvent, PlayerTurnStartEvent, RoundGroupSpendsTurn, RoundGroupSpendsTurnEvent, RoundGroupTurnEnds, RoundPlayerCountinuesAttacking, RoundPlayerTurnStarts, UnitHealed, UnitHealedEvent } from '../events';
 import { BattleStateService } from '../mw-battle-state.service';
 import { MwCurrentPlayerStateService, PlayerState } from '../mw-current-player-state.service';
 import { MwPlayersService } from '../mw-players.service';
 import { MwStructuresService } from '../mw-structures.service';
+import { State } from '../state.service';
 
 @Injectable()
 export class BattleController extends StoreClient() {
@@ -15,6 +16,7 @@ export class BattleController extends StoreClient() {
     private curPlayerState: MwCurrentPlayerStateService,
     private strucuresService: MwStructuresService,
     private playersService: MwPlayersService,
+    private state: State,
   ) {
     super();
   }
@@ -143,6 +145,18 @@ export class BattleController extends StoreClient() {
   @Notify(GroupSpeedChanged)
   public updateFightQueryDueToSpeedChange(): void {
     this.battleState.resortFightQueue();
+  }
+
+  @Notify(FightEnds)
+  public cleanUpHandlersOnFightEnd(): void {
+    this.events.dispatch(CleanUpHandlersOnFightEnd());
+  }
+
+  @Notify(CleanUpHandlersOnFightEnd)
+  public cleanUpHandlers(): void {
+    this.state.eventHandlers.spells.removeAllHandlers();
+    // need to think about items, they are being initialized outsize of combat
+    // this.state.eventHandlers.items.removeAllHandlers();
   }
 
   private enemyHasAnyLivingUnits(): boolean {

--- a/src/app/features/services/controllers/combat.service.ts
+++ b/src/app/features/services/controllers/combat.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
-import { SpellEventTypes } from 'src/app/core/spells';
+import { spellEvents } from 'src/app/core/spells';
 import { Notify, StoreClient, WireMethod } from 'src/app/store';
-import { StructCompleted, FightStarts, GroupAttacked, GroupAttackedEvent, CombatAttackInteraction, CombatInteractionEnum, CombatInteractionStateEvent, RoundGroupSpendsTurn, FightNextRoundStarts, NextRoundStarts, GroupDies, GroupDiesEvent } from '../events';
+import { CombatAttackInteraction, CombatInteractionEnum, CombatInteractionStateEvent, FightNextRoundStarts, FightStarts, GroupAttacked, GroupAttackedEvent, GroupDies, GroupDiesEvent, NextRoundStarts, RoundGroupSpendsTurn, StructCompleted } from '../events';
 import { CombatInteractorService } from '../mw-combat-interactor.service';
 
 @Injectable()
@@ -57,10 +57,7 @@ export class CombatController extends StoreClient() {
   @WireMethod(FightNextRoundStarts)
   public resetCooldownsAndEmitNewRoundEventToSpells(event: NextRoundStarts): void {
     this.combatInteractor.triggerEventForAllSpellsHandler(
-      SpellEventTypes.NewRoundBegins,
-      {
-        round: event.round,
-      },
+      spellEvents.NewRoundBegins({ round: event.round }),
     );
 
     this.combatInteractor.resetAllUnitGroupsCooldowns();

--- a/src/app/features/services/controllers/items.service.ts
+++ b/src/app/features/services/controllers/items.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
-import { GameEventTypes } from 'src/app/core/items';
-import { StoreClient, WireMethod, Notify } from 'src/app/store';
+import { itemEvents } from 'src/app/core/items';
+import { Notify, StoreClient, WireMethod } from 'src/app/store';
 import { FightNextRoundStarts, FightStarts, NextRoundStarts } from '../events';
 import { MwItemsService } from '../mw-items.service';
 
@@ -15,17 +15,11 @@ export class ItemsController extends StoreClient() {
 
   @WireMethod(FightNextRoundStarts)
   public triggerEventsForItems(event: NextRoundStarts): void {
-    this.itemsService.triggerEventForAllItemsHandlers(
-      GameEventTypes.NewRoundBegins,
-      { round: event.round },
-    );
+    this.itemsService.triggerEventForAllItemsHandlers(itemEvents.NewRoundBegins({ round: event.round }));
   }
 
   @Notify(FightStarts)
   public trigger(): void {
-    this.itemsService.triggerEventForAllItemsHandlers(
-      GameEventTypes.NewRoundBegins,
-      { round: 0 },
-    )
+    this.itemsService.triggerEventForAllItemsHandlers(itemEvents.NewRoundBegins({ round: 0 }));
   }
 }

--- a/src/app/features/services/controllers/player.service.ts
+++ b/src/app/features/services/controllers/player.service.ts
@@ -5,6 +5,7 @@ import { FightNextRoundStarts, FightStarts, PlayerEquipsItem, PlayerEquipsItemAc
 import { MwCurrentPlayerStateService } from '../mw-current-player-state.service';
 import { MwItemsService } from '../mw-items.service';
 import { MwSpellsService } from '../mw-spells.service';
+import { State } from '../state.service';
 
 @Injectable()
 export class PlayerController extends StoreClient() {
@@ -13,6 +14,7 @@ export class PlayerController extends StoreClient() {
     private curPlayerState: MwCurrentPlayerStateService,
     private itemsService: MwItemsService,
     private spellsService: MwSpellsService,
+    private state: State,
   ) {
     super();
   }
@@ -84,7 +86,7 @@ export class PlayerController extends StoreClient() {
       player.hero.stats.bonusDefence -= item.baseType.staticMods.playerBonusDefence;
     }
 
-
     player.hero.spells = player.hero.spells.filter(spell => spell.sourceInfo.item !== item);
+    this.state.eventHandlers.items.removeAllHandlersForRef(item);
   }
 }

--- a/src/app/features/services/controllers/ui.service.ts
+++ b/src/app/features/services/controllers/ui.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { SpellEventTypes } from 'src/app/core/spells';
+import { spellEvents } from 'src/app/core/spells';
 import { ActionHintTypeEnum, SpellTargetActionHint } from 'src/app/core/ui';
 import { UnitGroupInstModel } from 'src/app/core/unit-types';
 import { Notify, StoreClient, WireMethod } from 'src/app/store';
@@ -116,8 +116,9 @@ export class UiController extends StoreClient() {
   public playerTargetsSpell(event: PlayerTargetsSpellEvent): void {
     this.combatInteractor.triggerEventForSpellHandler(
       event.spell,
-      SpellEventTypes.PlayerTargetsSpell,
-      { target: event.target },
+      spellEvents.PlayerTargetsSpell({
+        target: event.target,
+      }),
     );
 
     this.curPlayerState.setPlayerState(PlayerState.Normal);
@@ -128,11 +129,10 @@ export class UiController extends StoreClient() {
   public playerUsesInstantSpell(event: PlayerTargetsInstantSpellEvent): void {
     this.combatInteractor.triggerEventForSpellHandler(
       event.spell,
-      SpellEventTypes.PlayerCastsInstantSpell,
-      {
+      spellEvents.PlayerCastsInstantSpell({
         player: event.player,
         spell: event.spell,
-      }
+      }),
     );
   }
 

--- a/src/app/features/services/events/battle/events.ts
+++ b/src/app/features/services/events/battle/events.ts
@@ -39,6 +39,6 @@ export const RoundPlayerCountinuesAttacking = battleEvent();
 
 export const FightNextRoundStarts = battleEvent<NextRoundStarts>();
 
-export const FightEnds = battleEvent<FightEndsEvent>();
+export const FightEnds = battleEvent<FightEndsEvent>('Fight Ends');
 
 export const UnitHealed = battleEvent<UnitHealedEvent>();

--- a/src/app/features/services/events/game/commands.ts
+++ b/src/app/features/services/events/game/commands.ts
@@ -1,0 +1,8 @@
+import { eventsForPrefix } from 'src/app/store';
+
+
+const commands = eventsForPrefix('[Commands]');
+
+// It feels rather like a semantic event, doesn't feel exactly like command
+//  or regular event
+export const CleanUpHandlersOnFightEnd = commands('Clear spells and items registries on fight end.');

--- a/src/app/features/services/events/game/index.ts
+++ b/src/app/features/services/events/game/index.ts
@@ -1,2 +1,3 @@
 export * from './events';
 export * from './types';
+export * from './commands';

--- a/src/app/features/services/mw-items.service.ts
+++ b/src/app/features/services/mw-items.service.ts
@@ -1,9 +1,10 @@
 import { Injectable } from '@angular/core';
 import { Colors } from 'src/app/core/assets';
-import { GameEventsHandlers, GameEventsMapping, ItemBaseModel, ItemInstanceModel } from 'src/app/core/items';
+import { ItemBaseModel, ItemInstanceModel } from 'src/app/core/items';
 import { PlayerInstanceModel } from 'src/app/core/players';
-import { EventsService } from 'src/app/store';
+import { EventInfo, EventsService } from 'src/app/store';
 import { InitItem } from './events';
+import { State } from './state.service';
 
 /* Unregister All items and spell handlers when Game was over... */
 /*  And not only when game is over, but also when fight is over/item gets unregistered, something like that */
@@ -13,10 +14,10 @@ import { InitItem } from './events';
 })
 export class MwItemsService {
 
-  public itemsHandlersMap: Map<ItemInstanceModel, GameEventsHandlers> = new Map();
 
   constructor(
     private events: EventsService,
+    private state: State,
   ) { }
 
   public createItem<T extends object>(itemBase: ItemBaseModel<T>): ItemInstanceModel {
@@ -44,20 +45,15 @@ export class MwItemsService {
     }));
   }
 
-  public triggerEventForAllItemsHandlers<T extends keyof GameEventsHandlers>(
-    eventType: T,
-    data: GameEventsMapping[T],
-  ): void {
-    this.itemsHandlersMap.forEach(spellHandlers => {
-      (spellHandlers?.[eventType] as (arg: GameEventsMapping[T]) => void)?.(data);
-    });
+  // Later may limit events only to item events
+  public triggerEventForAllItemsHandlers(event: EventInfo): void {
+    this.state.eventHandlers.items.triggerAllHandlersByEvent(event);
   }
 
-  public triggerEventForItemHandlers<T extends keyof GameEventsHandlers>(
-    spell: ItemInstanceModel,
-    eventType: T,
-    data: GameEventsMapping[T],
+  public triggerEventForItemHandlers(
+    item: ItemInstanceModel,
+    event: EventInfo,
   ): void {
-    (this.itemsHandlersMap.get(spell)?.[eventType] as (arg: GameEventsMapping[T]) => void)?.(data);
+    this.state.eventHandlers.items.triggerRefEventHandlers(item, event);
   }
 }

--- a/src/app/features/services/state.service.ts
+++ b/src/app/features/services/state.service.ts
@@ -1,9 +1,12 @@
 import { Injectable } from '@angular/core';
 import { Fraction } from 'src/app/core/fractions';
 import { HeroBase } from 'src/app/core/heroes';
+import { ItemInstanceModel } from 'src/app/core/items';
 import { defaultTravelPointsPerDay } from 'src/app/core/locations';
 import { PlayerInstanceModel } from 'src/app/core/players';
+import { SpellInstance } from 'src/app/core/spells';
 import { Town } from 'src/app/core/towns';
+import { RefEventTriggersRegistry } from 'src/app/core/triggers';
 import { UnitsOrientation } from 'src/app/core/ui';
 
 /*
@@ -40,9 +43,9 @@ export class State {
   public settings: {
     orientation: UnitsOrientation,
   } = {
-    // Wire it to localStorage I suppose
-    orientation: UnitsOrientation.Vertical,
-  };
+      // Wire it to localStorage I suppose
+      orientation: UnitsOrientation.Vertical,
+    };
 
   public gameState!: {
     players: PlayerInstanceModel[];
@@ -55,4 +58,12 @@ export class State {
     currentPlayer: PlayerInstanceModel;
     enemyPlayer: PlayerInstanceModel;
   };
+
+  public eventHandlers: {
+    spells: RefEventTriggersRegistry<SpellInstance>,
+    items: RefEventTriggersRegistry<ItemInstanceModel>,
+  } = {
+      spells: new RefEventTriggersRegistry<SpellInstance>(),
+      items: new RefEventTriggersRegistry<ItemInstanceModel>(),
+    };
 }

--- a/src/app/notes/dev.notes.ts
+++ b/src/app/notes/dev.notes.ts
@@ -1,4 +1,32 @@
-/* 
+/*
+  At some point I might need 'source' property,
+    like where did buff come from, or from which item did spell come.
+
+  I was thinking to add some kind of 'source' prop to
+    objects, but maybe I can store some relations
+    outside, like some global map or something.
+*/
+
+/*
+  In theory, if I want something like
+  @WireProp(SomeEvent)
+  public prop = event => {};
+
+  It can become something like
+  @WireProp()
+  public doOnEvent = onEvent(SomeEvent, (event) => {});
+
+  this might even work with `this`
+
+  onEvent might return some technical type, but can extract
+    event type from SomeEvent, with no need to specify specific type
+    (allow type to sink down)
+
+  then.. such functions might do something else... maybe pipes
+    could be possible in some ways, maybe pipes
+*/
+
+/*
     So far I'm not sure about using classes for my ingame entities.
         It's like, the functionality related to some entity may require
         application-wide scope, hence that, it's hard to figure out
@@ -14,7 +42,7 @@
         things.
 */
 
-/* 
+/*
     It is better to have related models extracted and coupled
         together. Sometimes it may lead to circular dependencies.
         It can be fought explicitly, using `import type {...} from '...';`

--- a/src/app/store/events/event-groups.ts
+++ b/src/app/store/events/event-groups.ts
@@ -1,0 +1,54 @@
+import { createEventType, EventType } from './events';
+
+type EventGroupList = Record<string | number, EventType<any>>;
+
+interface EventGroup<T extends EventGroupList> {
+  events: T,
+  // poor refactoring, but later it feels poor overall
+  getEventByName<K extends keyof T>(eventName: K): T[K];
+}
+
+export function createEventsGroup<T extends EventGroupList>({ events, prefix }: {
+  prefix: string,
+  events: T,
+}): EventGroup<T> {
+
+  Object.entries(events).forEach(([eventName, event]) => {
+    event.__info.__name = `${prefix}:${eventName}, ${event.__info.__name}`;
+    // event.toString = function () {
+    //   return `[${prefix}] Event:${eventName}`;
+    // };
+  });
+
+  return {
+    events,
+    getEventByName<K extends keyof T>(eventName: K) { return events[eventName] }
+  };
+}
+
+export type KeysOfEventGroup<T extends EventGroup<any>> = keyof T['events'];
+export type EventsOfGroup<T extends EventGroup<any>> = T['events'][keyof T['events']];
+
+// Api tests:
+
+// const triggersEvents = createEventsGroup({
+//   prefix: 'Triggers',
+//   events: {
+//     GameStarts: createEventType<{ round: number }>(),
+//     GameEnds: createEventType<{ spellsCount: 1, round: number }>(),
+//     UnitAttacks: createEventType<{ target: object }>(),
+//     NewRoundBegins: createEventType(),
+//   },
+// });
+
+// it works, but doesn't refactor well
+// triggersEvents.getEventByName('GameStarts')({ round: 1 });
+// triggersEvents.events['GameStarts']({ round: 1 });
+// triggersEvents.events.GameStarts;
+
+// type TriggerKeys = KeysOfEventGroup<typeof triggersEvents>;
+// type TriggerEvents = EventsOfGroup<typeof triggersEvents>;
+
+// also refactors a bit poorly
+// const key: TriggerKeys = 'GameStarts';
+// const events: TriggerEvents = triggersEvents.events.GameStarts;

--- a/src/app/store/events/events.service.ts
+++ b/src/app/store/events/events.service.ts
@@ -36,7 +36,9 @@ export class EventsService {
     this.eventStream$.next(event);
   }
 
-  constructor() { }
+  constructor() {
+    // this.eventStream$.subscribe(event => console.log('[Event]:', event));
+  }
 
   public onEvent<T extends object>(event: EventType<T>): Observable<T> {
     return this.eventStream$.pipe(

--- a/src/app/store/events/events.ts
+++ b/src/app/store/events/events.ts
@@ -1,26 +1,32 @@
 
 export interface EventInfo {
+  // global numeric id
   __id: number;
+  // text description
   __name: string;
-  // __type: () => void;
+  // it's event type
+  __type: (() => void) | null;
 }
 
-export interface EventType<T extends object = {}> {
+export interface EventType<T extends object = object> {
   __info: EventInfo;
   (props?: T): T & EventInfo;
 }
 
 let eventId: number = 0;
 
-export function eventType<T extends object = {}>(
+export function createEventType<T extends object = {}>(
   name: string = ''
 ): EventType<T> {
   const eventInfo: EventInfo = {
     __id: eventId,
     __name: name,
+    __type: null,
   };
 
   const event = function eventFn(data: T = {} as any) {
+    eventInfo.__type = eventFn;
+
     return {
       ...eventInfo,
       ...data,
@@ -34,8 +40,8 @@ export function eventType<T extends object = {}>(
   return event;
 }
 
-export function eventsForPrefix(prefix: string): typeof eventType {
-  return (name?: string) => eventType(`${prefix} ${name}`);
+export function eventsForPrefix(prefix: string): typeof createEventType {
+  return (name?: string) => createEventType(`${prefix} ${name}`);
 }
 
 // export function eventsFromKeysOf<T extends object>(prefix: string): <K extends keyof T>(name?: string) => EventType<{ [P in K]: T[P] }> {


### PR DESCRIPTION
In this PR event systems were updated to common standard, RefEventTriggersRegistry was introduced to simplify working with events attached to certain entities (Items, Spells, and anything else in theory). Concept of Event Groups is introduced, it can provide easier logging/debugging experience for events along with some other things. Also minor fixes and improvements.