### PR TITLE
Overhaul: Introduce GameObjectsManager, convert UnitGroup, Item, Hero, Player, Spell, Structure into GameObjects

### DIFF
--- a/src/app/core/api/combat-api/types.ts
+++ b/src/app/core/api/combat-api/types.ts
@@ -1,7 +1,7 @@
 import { Modifiers } from '../../modifiers';
-import { PlayerInstanceModel } from '../../players';
-import { DefaultSpellStateType, SpellInstance } from '../../spells';
-import { UnitBase, UnitGroupInstModel } from '../../unit-types';
+import { Player } from '../../players';
+import { DefaultSpellStateType, Spell } from '../../spells';
+import { UnitBaseType, UnitGroup } from '../../unit-types';
 import { SpellsApi } from '../game-api';
 
 export interface PostDamageInfo {
@@ -26,10 +26,10 @@ export interface HealingInfo {
 }
 
 export interface CombatActionsRef extends SpellsApi {
-  summonUnitsForPlayer(ownerPlayer: PlayerInstanceModel, unitType: UnitBase, unitNumber: number): UnitGroupInstModel;
+  summonUnitsForPlayer(ownerPlayer: Player, unitType: UnitBaseType, unitNumber: number): UnitGroup;
 
   dealDamageTo: (
-    target: UnitGroupInstModel,
+    target: UnitGroup,
     damage: number,
     damageType: DamageType,
     postActionFn?: (actionInfo: PostDamageInfo) => void,
@@ -37,32 +37,32 @@ export interface CombatActionsRef extends SpellsApi {
 
   // adds spell instance to specific unit group.
   addSpellToUnitGroup: <T = DefaultSpellStateType>(
-    target: UnitGroupInstModel,
-    spell: SpellInstance<T>,
-    ownerPlayer: PlayerInstanceModel,
+    target: UnitGroup,
+    spell: Spell<T>,
+    ownerPlayer: Player,
   ) => void;
 
   // Removes spell instance from the target unit group and from battle events system.
   removeSpellFromUnitGroup: <T = DefaultSpellStateType>(
-    target: UnitGroupInstModel,
-    spell: SpellInstance<T>,
+    target: UnitGroup,
+    spell: Spell<T>,
   ) => void;
 
-  getUnitGroupsOfPlayer: (player: PlayerInstanceModel) => UnitGroupInstModel[];
+  getUnitGroupsOfPlayer: (player: Player) => UnitGroup[];
 
-  getAliveUnitGroupsOfPlayer: (player: PlayerInstanceModel) => UnitGroupInstModel[];
+  getAliveUnitGroupsOfPlayer: (player: Player) => UnitGroup[];
 
-  getRandomEnemyPlayerGroup: () => UnitGroupInstModel;
+  getRandomEnemyPlayerGroup: () => UnitGroup;
 
-  getEnemyPlayer: () => PlayerInstanceModel;
+  getEnemyPlayer: () => Player;
 
   historyLog: (plainMsg: string) => void;
 
   createModifiers: (modifiers: Modifiers) => Modifiers;
 
-  addModifiersToUnitGroup: (target: UnitGroupInstModel, modifiers: Modifiers) => void;
+  addModifiersToUnitGroup: (target: UnitGroup, modifiers: Modifiers) => void;
 
-  removeModifiresFromUnitGroup: (target: UnitGroupInstModel, modifiers: Modifiers) => void;
+  removeModifiresFromUnitGroup: (target: UnitGroup, modifiers: Modifiers) => void;
 
-  healUnit: (unit: UnitGroupInstModel, healValue: number) => HealingInfo;
+  healUnit: (unit: UnitGroup, healValue: number) => HealingInfo;
 }

--- a/src/app/core/api/game-api/types.ts
+++ b/src/app/core/api/game-api/types.ts
@@ -1,25 +1,25 @@
-import { PlayerInstanceModel } from '../../players';
+import { Player } from '../../players';
 import { Resources, ResourceType } from '../../resources';
-import { SpellInstance, SpellModel } from '../../spells';
-import { UnitGroupInstModel, UnitBase } from '../../unit-types';
+import { Spell, SpellBaseType } from '../../spells';
+import { UnitGroup, UnitBaseType } from '../../unit-types';
 import { SpellCreationOptions } from '../combat-api';
 
 export interface PlayersApi {
-  addManaToPlayer: (player: PlayerInstanceModel, mana: number) => void;
-  addMaxManaToPlayer: (player: PlayerInstanceModel, plusToMaxMana: number) => void;
+  addManaToPlayer: (player: Player, mana: number) => void;
+  addMaxManaToPlayer: (player: Player, plusToMaxMana: number) => void;
 
-  addSpellToPlayerHero: (player: PlayerInstanceModel, spell: SpellInstance) => void;
+  addSpellToPlayerHero: (player: Player, spell: Spell) => void;
 
-  getCurrentPlayer: () => PlayerInstanceModel;
-  getCurrentPlayerUnitGroups: () => UnitGroupInstModel[];
+  getCurrentPlayer: () => Player;
+  getCurrentPlayerUnitGroups: () => UnitGroup[];
 
-  addUnitGroupToPlayer: (player: PlayerInstanceModel, unitType: UnitBase, count: number) => void;
-  addExperienceToPlayer: (player: PlayerInstanceModel, xpAmount: number) => void;
+  addUnitGroupToPlayer: (player: Player, unitType: UnitBaseType, count: number) => void;
+  addExperienceToPlayer: (player: Player, xpAmount: number) => void;
 
-  giveResourceToPlayer: (player: PlayerInstanceModel, type: ResourceType, amount: number) => void;
-  giveResourcesToPlayer: (player: PlayerInstanceModel, resources: Resources) => void;
+  giveResourceToPlayer: (player: Player, type: ResourceType, amount: number) => void;
+  giveResourcesToPlayer: (player: Player, resources: Resources) => void;
 }
 
 export interface SpellsApi {
-  createSpellInstance: <T>(spell: SpellModel<T>, options?: SpellCreationOptions<T>) => SpellInstance<T>;
+  createSpellInstance: <T>(spell: SpellBaseType<T>, options?: SpellCreationOptions<T>) => Spell<T>;
 }

--- a/src/app/core/api/vfx-api/types.ts
+++ b/src/app/core/api/vfx-api/types.ts
@@ -1,4 +1,4 @@
-import { UnitGroupInstModel } from '../../unit-types';
+import { UnitGroup } from '../../unit-types';
 
 /* Think on better namings and structure for effects and animations */
 export enum AnimationElementType {
@@ -75,6 +75,6 @@ export interface CustomAnimationData {
 
 /*  replace data: object with normal type */
 export interface VfxApi {
-    createEffectForUnitGroup(target: UnitGroupInstModel, animation: EffectAnimation, options?: EffectOptions): void;
-    createFloatingMessageForUnitGroup(target: UnitGroupInstModel, data: CustomizableAnimationData, options: EffectOptions): void;
+    createEffectForUnitGroup(target: UnitGroup, animation: EffectAnimation, options?: EffectOptions): void;
+    createFloatingMessageForUnitGroup(target: UnitGroup, data: CustomizableAnimationData, options: EffectOptions): void;
 }

--- a/src/app/core/config/config.ts
+++ b/src/app/core/config/config.ts
@@ -2,4 +2,5 @@
 // basic config
 export const CONFIG = {
   logEvents: false,
+  logGameObjects: true,
 } as const;

--- a/src/app/core/events/battle/events.ts
+++ b/src/app/core/events/battle/events.ts
@@ -1,7 +1,7 @@
-import { PlayerModel } from 'src/app/core/players';
 import { createEventType } from 'src/app/store';
 import { props } from "../common";
 import { CombatInteractionStateEvent, FightEndsEvent, GroupAttackedEvent, GroupDamagedByGroupEvent, GroupDiesEvent, GroupTakesDamageEvent, NextRoundStarts, PlayerTargetsInstantSpellEvent, PlayerTargetsSpellEvent, PlayerTurnStartEvent, RoundGroupSpendsTurnEvent, UnitHealedEvent, UnitSummonedEvent } from "./types";
+import { Player } from '../../players';
 
 const battleEvent = createEventType;
 
@@ -31,7 +31,7 @@ export const GroupDies = battleEvent<GroupDiesEvent>();
 
 export const RoundGroupSpendsTurn = battleEvent<RoundGroupSpendsTurnEvent>();
 
-export const RoundGroupTurnEnds = battleEvent<{ playerEndsTurn: PlayerModel }>();
+export const RoundGroupTurnEnds = battleEvent<{ playerEndsTurn: Player }>();
 
 export const RoundPlayerTurnStarts = battleEvent<PlayerTurnStartEvent>();
 

--- a/src/app/core/events/battle/types.ts
+++ b/src/app/core/events/battle/types.ts
@@ -1,6 +1,6 @@
-import { PlayerInstanceModel, PlayerModel } from 'src/app/core/players';
+import { Player } from 'src/app/core/players';
 import { StructureModel } from 'src/app/core/structures';
-import { UnitBase, UnitGroupInstModel } from 'src/app/core/unit-types';
+import { UnitBaseType, UnitGroup } from 'src/app/core/unit-types';
 import { props } from '../common';
 
 export enum CombatInteractionEnum {
@@ -10,7 +10,7 @@ export enum CombatInteractionEnum {
 }
 
 export type GroupTakesDamageEvent = {
-  group: UnitGroupInstModel;
+  group: UnitGroup;
   registerLoss: boolean;
   unitLoss: number;
 };
@@ -21,14 +21,14 @@ export type GroupDamagedByGroupEvent = props<'attackingGroup' | 'attackedGroup' 
 
 export type RoundGroupSpendsTurnEvent = {
   groupStillAlive: boolean;
-  group: UnitGroupInstModel;
+  group: UnitGroup;
   groupHasMoreTurns: boolean;
-  groupPlayer: PlayerModel;
+  groupPlayer: Player;
 };
 
 export type PlayerTurnStartEvent = {
-  currentPlayer: PlayerModel;
-  previousPlayer: PlayerModel;
+  currentPlayer: Player;
+  previousPlayer: Player;
 };
 
 export type GroupAttackedEvent = props<'attackedGroup' | 'attackingGroup'>;
@@ -50,6 +50,6 @@ export type FightEndsEvent = {
 
 export type UnitSummonedEvent = {
   // ownerPlayer: PlayerInstanceModel;
-  unitGroup: UnitGroupInstModel;
+  unitGroup: UnitGroup;
   // unitNumber: number;
 };

--- a/src/app/core/events/common.ts
+++ b/src/app/core/events/common.ts
@@ -1,20 +1,20 @@
-import { PlayerInstanceModel, PlayerModel } from 'src/app/core/players';
-import { SpellInstance } from 'src/app/core/spells';
-import { UnitGroupInstModel } from 'src/app/core/unit-types';
+import { Player } from 'src/app/core/players';
+import { Spell } from 'src/app/core/spells';
+import { UnitGroup } from 'src/app/core/unit-types';
 import { CombatInteractionEnum } from "./battle";
 
 export interface CommonEventProps {
-  unitGroup: UnitGroupInstModel;
-  player: PlayerInstanceModel;
-  targetPlayer: PlayerModel;
-  spell: SpellInstance;
-  target: UnitGroupInstModel;
+  unitGroup: UnitGroup;
+  player: Player;
+  targetPlayer: Player;
+  spell: Spell;
+  target: UnitGroup;
 
-  attackingPlayer: PlayerInstanceModel;
-  attackedPlayer: PlayerInstanceModel;
+  attackingPlayer: Player;
+  attackedPlayer: Player;
 
-  attackingGroup: UnitGroupInstModel;
-  attackedGroup: UnitGroupInstModel;
+  attackingGroup: UnitGroup;
+  attackedGroup: UnitGroup;
 
   action: CombatInteractionEnum;
 

--- a/src/app/core/events/game/commands.ts
+++ b/src/app/core/events/game/commands.ts
@@ -1,5 +1,5 @@
 import { createEventType } from 'src/app/store';
-import { DisplayPlayerRewardAction, PanMapCameraCenterAction } from './types';
+import { DisplayPlayerRewardAction, InitGameObjectApiParams, PanMapCameraCenterAction } from './types';
 
 
 const commands = createEventType;
@@ -28,3 +28,5 @@ export const OpenSettings = commands('Open Game settings');
 export const GameOpenMapStructuresScreen = commands('Open map structures screen');
 
 export const DisplayPlayerRewardPopup = commands<DisplayPlayerRewardAction>();
+
+export const InitGameObjectApi = commands<InitGameObjectApiParams>();

--- a/src/app/core/events/game/types.ts
+++ b/src/app/core/events/game/types.ts
@@ -1,18 +1,19 @@
-import { ItemInstanceModel } from 'src/app/core/items';
-import { PlayerInstanceModel } from 'src/app/core/players';
-import { SpellInstance } from 'src/app/core/spells';
-import { NeutralCampStructure, StructureModel } from 'src/app/core/structures';
-import { UnitGroupInstModel } from 'src/app/core/unit-types';
+import { ItemObject } from 'src/app/core/items';
+import { Player } from 'src/app/core/players';
+import { Spell } from 'src/app/core/spells';
+import { StructureModel } from 'src/app/core/structures';
+import { UnitGroup } from 'src/app/core/unit-types';
 import { Hero } from '../../heroes';
+import { GameObject } from '../../game-objects';
 
 export type StructSelectedEvent = { struct: StructureModel };
-export type NeutralStructParams = { struct: NeutralCampStructure };
+export type NeutralStructParams = { struct: StructureModel };
 export type NewDayParams = { day: number };
-export type FightStartsEvent = { unitGroups: UnitGroupInstModel[], players: PlayerInstanceModel[] };
-export type InitSpellAction = { spell: SpellInstance, player: PlayerInstanceModel, ownerUnit?: UnitGroupInstModel };
-export type InitItemAction = { item: ItemInstanceModel, ownerPlayer: PlayerInstanceModel };
-export type PlayerEquipsItemAction = { player: PlayerInstanceModel, item: ItemInstanceModel };
-export type PlayerUnequipsItemAction = { player: PlayerInstanceModel, item: ItemInstanceModel };
+export type FightStartsEvent = { unitGroups: UnitGroup[], players: Player[] };
+export type InitSpellAction = { spell: Spell, player: Player, ownerUnit?: UnitGroup };
+export type InitItemAction = { item: ItemObject, ownerPlayer: Player };
+export type PlayerEquipsItemAction = { player: Player, item: ItemObject };
+export type PlayerUnequipsItemAction = { player: Player, item: ItemObject };
 
 export type PanMapCameraCenterAction = { x: number; y: number; };
 
@@ -27,3 +28,4 @@ export interface RewardModel {
 }
 
 export type DisplayPlayerRewardAction = { title: string; subTitle: string; rewards: RewardModel[] };
+export type InitGameObjectApiParams = { gameObject: GameObject };

--- a/src/app/core/events/game/types.ts
+++ b/src/app/core/events/game/types.ts
@@ -1,4 +1,4 @@
-import { ItemObject } from 'src/app/core/items';
+import { Item } from 'src/app/core/items';
 import { Player } from 'src/app/core/players';
 import { Spell } from 'src/app/core/spells';
 import { StructureModel } from 'src/app/core/structures';
@@ -11,9 +11,9 @@ export type NeutralStructParams = { struct: StructureModel };
 export type NewDayParams = { day: number };
 export type FightStartsEvent = { unitGroups: UnitGroup[], players: Player[] };
 export type InitSpellAction = { spell: Spell, player: Player, ownerUnit?: UnitGroup };
-export type InitItemAction = { item: ItemObject, ownerPlayer: Player };
-export type PlayerEquipsItemAction = { player: Player, item: ItemObject };
-export type PlayerUnequipsItemAction = { player: Player, item: ItemObject };
+export type InitItemAction = { item: Item, ownerPlayer: Player };
+export type PlayerEquipsItemAction = { player: Player, item: Item };
+export type PlayerUnequipsItemAction = { player: Player, item: Item };
 
 export type PanMapCameraCenterAction = { x: number; y: number; };
 

--- a/src/app/core/events/ui/types.ts
+++ b/src/app/core/events/ui/types.ts
@@ -1,4 +1,4 @@
-import { UnitGroupInstModel } from 'src/app/core/unit-types';
+import { UnitGroup } from 'src/app/core/unit-types';
 import { props } from '../common';
 
 export enum HoverTypeEnum {
@@ -9,8 +9,8 @@ export enum HoverTypeEnum {
 
 export type PlayerHoversCardEvent = {
   hoverType: HoverTypeEnum;
-  currentCard?: UnitGroupInstModel;
-  hoveredCard?: UnitGroupInstModel;
+  currentCard?: UnitGroup;
+  hoveredCard?: UnitGroup;
 }
 
 export type PlayerClicksEnemyGroupEvent = props<'attackedGroup' | 'attackingGroup' | 'attackingPlayer'>;

--- a/src/app/core/fractions/fractions.ts
+++ b/src/app/core/fractions/fractions.ts
@@ -1,6 +1,6 @@
 
 import type { HeroBase } from '../heroes';
-import type { UnitBase } from '../unit-types';
+import type { UnitBaseType } from '../unit-types';
 import { Fraction } from './types';
 
 /* might be adjusted in the future */
@@ -45,9 +45,9 @@ export const Fractions = {
       },
       findBaseUnitType(upgradedType) {
         /* todo: fix this place later, remove any */
-        return Object.values<any>(this.unitTypes).find((unitType: UnitBase) => unitType.upgradeDetails?.target === upgradedType) as UnitBase;
+        return Object.values<any>(this.unitTypes).find((unitType: UnitBaseType) => unitType.upgradeDetails?.target === upgradedType) as UnitBaseType;
       },
-      getUnitType(unitTypeName: T): UnitBase {
+      getUnitType(unitTypeName: T): UnitBaseType {
         return this.unitTypes[unitTypeName]!;
       },
       createHero(

--- a/src/app/core/fractions/types.ts
+++ b/src/app/core/fractions/types.ts
@@ -1,10 +1,10 @@
 import type { HeroBase, HeroBaseStats } from '../heroes';
 import type { TownBase } from '../towns';
-import type { UnitBase } from '../unit-types';
+import type { UnitBaseType } from '../unit-types';
 
 /* might be adjusted in the future */
 
-export type UnitTypeCreationParams = Omit<UnitBase, 'type' | 'fraction'>;
+export type UnitTypeCreationParams = Omit<UnitBaseType, 'type' | 'fraction'>;
 
 export interface Fraction<T extends string> {
   name: string;
@@ -12,12 +12,12 @@ export interface Fraction<T extends string> {
   title: string;
   icon: string;
   townBase: TownBase<any> | null;
-  unitTypes: { [key in T]?: UnitBase };
-  defineUnitType(unitTypeName: T, params: UnitTypeCreationParams): UnitBase;
-  getUnitType(unitTypeName: T): UnitBase;
+  unitTypes: { [key in T]?: UnitBaseType };
+  defineUnitType(unitTypeName: T, params: UnitTypeCreationParams): UnitBaseType;
+  getUnitType(unitTypeName: T): UnitBaseType;
   createHero(config: Pick<HeroBase, 'name'> & HeroBaseStats): HeroBase;
   getAllHeroes(): HeroBase[];
-  findBaseUnitType(upgradedType: UnitBase): UnitBase;
+  findBaseUnitType(upgradedType: UnitBaseType): UnitBaseType;
   getTownBase(): TownBase<any> | null;
   setTownBase(townBase: TownBase<any>): void;
 }

--- a/src/app/core/game-objects/game-object.ts
+++ b/src/app/core/game-objects/game-object.ts
@@ -1,0 +1,26 @@
+import { SpellsApi } from '../api/game-api';
+
+// extend this api
+export interface GameObjectApi {
+  spells: SpellsApi;
+}
+
+export class GameObject<CreationParams extends object = object> {
+  public readonly id: string;
+
+  public static readonly categoryId: string = 'game-object';
+
+  private readonly api!: { spells: SpellsApi };
+
+  constructor(id: string) {
+    this.id = id;
+  }
+
+  create(params: CreationParams): void { }
+
+  protected getApi(): GameObjectApi {
+    return this.api;
+  }
+}
+
+export type CreationParams<T> = T extends GameObject<infer K> ? K : never;

--- a/src/app/core/game-objects/index.ts
+++ b/src/app/core/game-objects/index.ts
@@ -1,0 +1,1 @@
+export * from './game-object';

--- a/src/app/core/heroes/types.ts
+++ b/src/app/core/heroes/types.ts
@@ -1,5 +1,5 @@
 import { GameObject } from '../game-objects';
-import { ItemBaseModel, ItemObject } from '../items';
+import { ItemBaseModel, Item } from '../items';
 import { InventoryItems } from '../items/inventory';
 import { Modifiers } from '../modifiers';
 import { ResourcesModel } from '../resources';
@@ -60,7 +60,7 @@ export class Hero extends GameObject<HeroCreationParams> {
   public stats!: HeroStats;
   public spells: Spell[] = [];
   public mods: Modifiers[] = [];
-  public items: ItemObject[] = [];
+  public items: Item[] = [];
   public base!: HeroBase;
   public inventory: InventoryItems = new InventoryItems();
 

--- a/src/app/core/items/inventory.ts
+++ b/src/app/core/items/inventory.ts
@@ -1,4 +1,4 @@
-import { ItemObject, ItemSlotType } from "./types";
+import { Item, ItemSlotType } from "./types";
 
 export interface ExtendedSlotType {
   icon: string;
@@ -7,9 +7,9 @@ export interface ExtendedSlotType {
 }
 
 export class InventoryItems {
-  private inventoryItemsMap: Map<ItemSlotType, ItemObject> = new Map();
+  private inventoryItemsMap: Map<ItemSlotType, Item> = new Map();
 
-  private equipedItemsSet: Set<ItemObject> = new Set();
+  private equipedItemsSet: Set<Item> = new Set();
 
   private static slotTypes: ItemSlotType[] = [
     ItemSlotType.Weapon,
@@ -40,11 +40,11 @@ export class InventoryItems {
     return this.extendedSlotsMap.get(slotType)!;
   }
 
-  public static filterItemsForSlot(slotType: ItemSlotType, items: ItemObject[]): ItemObject[] {
+  public static filterItemsForSlot(slotType: ItemSlotType, items: Item[]): Item[] {
     return items.filter(item => item.baseType.slotType === slotType);
   }
 
-  public equipItem(item: ItemObject): void {
+  public equipItem(item: Item): void {
     const itemType = item.baseType.slotType;
 
     const prevItem = this.inventoryItemsMap.get(itemType);
@@ -58,7 +58,7 @@ export class InventoryItems {
     this.equipedItemsSet.add(item);
   }
 
-  public unequipItem(item: ItemObject): void {
+  public unequipItem(item: Item): void {
     this.inventoryItemsMap.delete(this.getItemSlotType(item));
     this.equipedItemsSet.delete(item);
   }
@@ -72,7 +72,7 @@ export class InventoryItems {
     }
   }
 
-  public getItemInSlot(slotType: ItemSlotType): ItemObject | null {
+  public getItemInSlot(slotType: ItemSlotType): Item | null {
     return this.inventoryItemsMap.get(slotType) || null;
   }
 
@@ -80,11 +80,11 @@ export class InventoryItems {
     return this.inventoryItemsMap.has(slotType);
   }
 
-  public getEquippedItems(): ItemObject[] {
+  public getEquippedItems(): Item[] {
     return [...this.equipedItemsSet];
   }
 
-  private getItemSlotType(item: ItemObject<object>): ItemSlotType {
+  private getItemSlotType(item: Item<object>): ItemSlotType {
     return item.baseType.slotType;
   }
 }

--- a/src/app/core/items/inventory.ts
+++ b/src/app/core/items/inventory.ts
@@ -1,4 +1,4 @@
-import { ItemInstanceModel, ItemSlotType } from "./types";
+import { ItemObject, ItemSlotType } from "./types";
 
 export interface ExtendedSlotType {
   icon: string;
@@ -7,9 +7,9 @@ export interface ExtendedSlotType {
 }
 
 export class InventoryItems {
-  private inventoryItemsMap: Map<ItemSlotType, ItemInstanceModel> = new Map();
+  private inventoryItemsMap: Map<ItemSlotType, ItemObject> = new Map();
 
-  private equipedItemsSet: Set<ItemInstanceModel> = new Set();
+  private equipedItemsSet: Set<ItemObject> = new Set();
 
   private static slotTypes: ItemSlotType[] = [
     ItemSlotType.Weapon,
@@ -40,11 +40,11 @@ export class InventoryItems {
     return this.extendedSlotsMap.get(slotType)!;
   }
 
-  public static filterItemsForSlot(slotType: ItemSlotType, items: ItemInstanceModel[]): ItemInstanceModel[] {
+  public static filterItemsForSlot(slotType: ItemSlotType, items: ItemObject[]): ItemObject[] {
     return items.filter(item => item.baseType.slotType === slotType);
   }
 
-  public equipItem(item: ItemInstanceModel): void {
+  public equipItem(item: ItemObject): void {
     const itemType = item.baseType.slotType;
 
     const prevItem = this.inventoryItemsMap.get(itemType);
@@ -58,7 +58,7 @@ export class InventoryItems {
     this.equipedItemsSet.add(item);
   }
 
-  public unequipItem(item: ItemInstanceModel): void {
+  public unequipItem(item: ItemObject): void {
     this.inventoryItemsMap.delete(this.getItemSlotType(item));
     this.equipedItemsSet.delete(item);
   }
@@ -72,7 +72,7 @@ export class InventoryItems {
     }
   }
 
-  public getItemInSlot(slotType: ItemSlotType): ItemInstanceModel | null {
+  public getItemInSlot(slotType: ItemSlotType): ItemObject | null {
     return this.inventoryItemsMap.get(slotType) || null;
   }
 
@@ -80,11 +80,11 @@ export class InventoryItems {
     return this.inventoryItemsMap.has(slotType);
   }
 
-  public getEquippedItems(): ItemInstanceModel[] {
+  public getEquippedItems(): ItemObject[] {
     return [...this.equipedItemsSet];
   }
 
-  private getItemSlotType(item: ItemInstanceModel<object>): ItemSlotType {
+  private getItemSlotType(item: ItemObject<object>): ItemSlotType {
     return item.baseType.slotType;
   }
 }

--- a/src/app/core/items/neutral/black-lich-sword.ts
+++ b/src/app/core/items/neutral/black-lich-sword.ts
@@ -7,6 +7,7 @@ export const BlackLichSwordItem: ItemBaseModel = {
   slotType: ItemSlotType.Weapon,
   staticMods: {
     playerBonusAttack: 3,
+    lifesteal: 10,
     /* Vampirism mod, maybe -1-2 to Defence */
   },
   icon: {

--- a/src/app/core/items/neutral/index.ts
+++ b/src/app/core/items/neutral/index.ts
@@ -1,7 +1,10 @@
+export * from './black-lich-sword';
 export * from './doomstring';
 export * from './eclipse-wand';
 export * from './ice-bow';
+export * from './irton-plate';
+export * from './lifeform';
 export * from './meteor-swords';
 export * from './wind-crest';
 export * from './wishmaster';
-
+export * from './rising-sun';

--- a/src/app/core/items/neutral/lifeform.ts
+++ b/src/app/core/items/neutral/lifeform.ts
@@ -1,0 +1,37 @@
+import { itemStatsDescr, spellDescrElem } from '../../ui';
+import { ItemBaseModel, ItemSlotType } from '../types';
+
+const healValue = 50;
+
+export const LifeformItem: ItemBaseModel = {
+  name: 'Lifeform',
+  slotType: ItemSlotType.Armor,
+  icon: {
+    icon: 'vest',
+  },
+  staticMods: {
+    playerBonusDefence: 12,
+    resistAll: 13,
+  },
+  description({ thisItem }) {
+    return {
+      descriptions: [
+        itemStatsDescr(thisItem),
+        spellDescrElem(`An incredible armor that shimmers with bright colors and emits life aura. Heals all units by ${healValue} in the beginning of each round.`),
+      ],
+    }
+  },
+  config: {
+    init({ events, actions, ownerPlayer }) {
+      events.on({
+        NewRoundBegins: () => {
+          const ownerUnitGroups = actions.getUnitGroupsOfPlayer(ownerPlayer);
+
+          ownerUnitGroups.forEach((unitGroup) => {
+            actions.healUnit(unitGroup, healValue);
+          });
+        },
+      })
+    }
+  },
+};

--- a/src/app/core/items/neutral/rising-sun.ts
+++ b/src/app/core/items/neutral/rising-sun.ts
@@ -1,0 +1,40 @@
+import { itemStatsDescr, spellDescrElem } from '../../ui';
+import { ItemBaseModel, ItemSlotType } from '../types';
+
+const healValue = 50;
+
+// Ideas for healing items:
+//  1. Heal random amount of units.
+//  2. Heal with ranged value (e.g. 25-40)
+export const RisingSunPendant: ItemBaseModel = {
+  name: 'Rising Sun',
+  icon: {
+    icon: 'gem-pendant',
+  },
+  slotType: ItemSlotType.Amulet,
+  staticMods: {
+    playerBonusDefence: 2,
+  },
+  description({ thisItem }) {
+    return {
+      descriptions: [
+        itemStatsDescr(thisItem),
+        spellDescrElem(`Each round heals your units by ${healValue}`),
+      ],
+    }
+  },
+  config: {
+    // todo: provide vfx
+    init({ events, actions, ownerPlayer }) {
+      events.on({
+        NewRoundBegins: () => {
+          const ownerUnitGroups = actions.getUnitGroupsOfPlayer(ownerPlayer);
+
+          ownerUnitGroups.forEach((unitGroup) => {
+            actions.healUnit(unitGroup, healValue);
+          });
+        },
+      })
+    }
+  },
+};

--- a/src/app/core/items/neutral/wishmaster.ts
+++ b/src/app/core/items/neutral/wishmaster.ts
@@ -8,7 +8,7 @@ export const WishmasterItem: ItemBaseModel = {
   staticMods: {
     playerBonusAttack: 8,
     playerBonusDefence: 7,
-    resistAll: 15,
+    resistAll: 13,
   },
   icon: {
     icon: 'feather-wing',

--- a/src/app/core/items/types.ts
+++ b/src/app/core/items/types.ts
@@ -1,39 +1,19 @@
-
-/*
-    I'm uncertain of what items model should consist.
-    Because of that, I feel like I need arrays.
-
-    Anyways, it's not thought through completely.
-        It will most surely require implementing new systems.
-
-    Especially for active abilities.
-
-    Also probably need to figure out more clearly the
-        stats of the units, and which systems I want to have
-        for them
-
-    Idea, Item: If army has unit of level 9, all gain bonus
-
-    Important: I think, it makes more sense for now to make
-        gameplay and main stats more interesting
-
-*/
-
 import { CombatActionsRef } from '../api/combat-api';
 import { Icon } from '../assets';
+import { GameObject } from '../game-objects';
 import { Hero } from '../heroes';
 import { Modifiers } from '../modifiers';
-import { PlayerInstanceModel } from '../players';
-import { SpellModel } from '../spells';
+import { Player } from '../players';
+import { SpellBaseType } from '../spells';
 import { DescriptionElement } from '../ui';
-import { UnitGroupModel } from '../unit-types';
+import { UnitGroup } from '../unit-types';
 import { ItemsEventsHandlers } from './item-events';
 
 
 export interface ItemRequirementModel<T extends object> {
   type: string;
   value?: number | string | boolean;
-  isRequirementMet?: (item: ItemBaseModel<T>, unitGroup: UnitGroupModel) => boolean;
+  isRequirementMet?: (item: ItemBaseModel<T>, unitGroup: UnitGroup) => boolean;
 }
 
 
@@ -47,7 +27,7 @@ export enum ItemSlotType {
 }
 
 export interface ItemDescriptionData<T extends object> {
-  thisItem: ItemInstanceModel<T>;
+  thisItem: ItemObject<T>;
 }
 
 export interface ItemDescription {
@@ -65,31 +45,36 @@ export interface ItemBaseModel<StateType extends object = object> {
   name: string;
   icon: Icon;
   staticMods: Modifiers;
-  /* Item can have reqs I think */
+
+  /* There could be some requirements: */
   // requirements: ItemRequirementModel[],
-  /* As well as modifiers */
-  // modifiers: ItemStatsModel[];
-  /* And description can be built like this */
-  // description: (item: ItemModel) => object[];
-  /* Description can indeed return an array of objects, as for spells, but for now.. keep it simple */
+
   description: (itemData: ItemDescriptionData<StateType>) => ItemDescription;
   config: {
     init: (combatRefs: {
       actions: CombatActionsRef,
       events: ItemsEventsRef,
-      ownerPlayer: PlayerInstanceModel,
+      ownerPlayer: Player,
       ownerHero: Hero,
-      thisInstance: ItemInstanceModel<StateType>,
+      thisInstance: ItemObject<StateType>,
     }) => void,
   },
-  /* todo: Spells by items can also have a separate coolrown queue */
-  bonusAbilities?: { spell: SpellModel, level: number }[];
-  /* Item class? */
-  /* Active abilities? This will require an entire system */
+  bonusAbilities?: { spell: SpellBaseType, level: number }[];
 }
 
-export interface ItemInstanceModel<T extends object = object> {
-  currentDescription: string; // string for now
-  baseType: ItemBaseModel<T>;
-  state: T;
+export interface ItemCreationParams<T extends object = object> {
+  itemBase: ItemBaseModel<T>;
+  state?: T;
+}
+
+export class ItemObject<T extends object = object> extends GameObject<ItemCreationParams<T>> {
+  public static readonly categoryId: string = 'item';
+
+  public baseType!: ItemBaseModel<T>;
+  public state?: T;
+
+  create(params: ItemCreationParams<T>): void {
+    this.baseType = params.itemBase;
+    this.state = params.state;
+  }
 }

--- a/src/app/core/items/types.ts
+++ b/src/app/core/items/types.ts
@@ -16,7 +16,6 @@ export interface ItemRequirementModel<T extends object> {
   isRequirementMet?: (item: ItemBaseModel<T>, unitGroup: UnitGroup) => boolean;
 }
 
-
 export enum ItemSlotType {
   Weapon = 'Weapon',
   Headgear = 'Headgear',
@@ -27,7 +26,7 @@ export enum ItemSlotType {
 }
 
 export interface ItemDescriptionData<T extends object> {
-  thisItem: ItemObject<T>;
+  thisItem: Item<T>;
 }
 
 export interface ItemDescription {
@@ -56,7 +55,7 @@ export interface ItemBaseModel<StateType extends object = object> {
       events: ItemsEventsRef,
       ownerPlayer: Player,
       ownerHero: Hero,
-      thisInstance: ItemObject<StateType>,
+      thisInstance: Item<StateType>,
     }) => void,
   },
   bonusAbilities?: { spell: SpellBaseType, level: number }[];
@@ -67,7 +66,7 @@ export interface ItemCreationParams<T extends object = object> {
   state?: T;
 }
 
-export class ItemObject<T extends object = object> extends GameObject<ItemCreationParams<T>> {
+export class Item<T extends object = object> extends GameObject<ItemCreationParams<T>> {
   public static readonly categoryId: string = 'item';
 
   public baseType!: ItemBaseModel<T>;

--- a/src/app/core/items/utils.ts
+++ b/src/app/core/items/utils.ts
@@ -6,7 +6,7 @@ export function createItem({ name, icon, slot, stats }: {
   name: string,
   icon: string,
   slot: ItemSlotType,
-  stats: Modifiers
+  stats: Modifiers,
 }): ItemBaseModel {
   return {
     name,

--- a/src/app/core/locations/common.ts
+++ b/src/app/core/locations/common.ts
@@ -20,6 +20,8 @@ import { StructureDescription } from './types';
 */
 const shift = 476;
 
+export const START_LOC_ID = 'start';
+
 function loc(location: number): number {
   return location + shift;
 }
@@ -30,7 +32,7 @@ const brBranch: StructureDescription[] = [
     x: loc(60),
     y: loc(30),
     icon: 'tombstone',
-    pathTo: '1',
+    pathTo: START_LOC_ID,
     struct: GraveyardStructure,
   },
   {
@@ -103,7 +105,7 @@ const brBranch: StructureDescription[] = [
 const fifthBranch: StructureDescription[] = [
   {
     id: '50',
-    pathTo: '1',
+    pathTo: START_LOC_ID,
     x: loc(-30),
     y: loc(70),
     icon: 'gold-bar',
@@ -118,7 +120,7 @@ const blBranch: StructureDescription[] = [
     x: loc(-70),
     y: loc(10),
     icon: 'sword',
-    pathTo: '1',
+    pathTo: START_LOC_ID,
 
     struct: BanditCamp,
   },
@@ -174,7 +176,7 @@ const tlBranch: StructureDescription[] = [
     x: loc(-60),
     y: loc(-60),
     icon: 'sword',
-    pathTo: '1',
+    pathTo: START_LOC_ID,
 
     struct: BanditCamp,
   },
@@ -215,7 +217,7 @@ const trBranch: StructureDescription[] = [
     x: loc(60),
     y: loc(-30),
     icon: 'lighthouse',
-    pathTo: '1',
+    pathTo: START_LOC_ID,
 
     struct: BeaconOfTheUndead,
   },
@@ -223,7 +225,7 @@ const trBranch: StructureDescription[] = [
 
 export const structsPreset1: StructureDescription[] = [
   {
-    id: '1',
+    id: START_LOC_ID,
     x: loc(0),
     y: loc(0),
     icon: 'campfire',

--- a/src/app/core/modifiers/formatters/item-formatters.ts
+++ b/src/app/core/modifiers/formatters/item-formatters.ts
@@ -6,4 +6,5 @@ export const modsFormatters: { [K in keyof Modifiers]: (val: ModifiersModel[K]) 
   playerBonusAttack: val => `${numMod(val)} Attack Rating`,
   playerBonusDefence: val => `${numMod(val)} Defence`,
   resistAll: val => `${numMod(val)}% All Resists`,
+  lifesteal: val => `${numMod(val)}% Lifesteal`,
 };

--- a/src/app/core/modifiers/modifiers.ts
+++ b/src/app/core/modifiers/modifiers.ts
@@ -23,6 +23,10 @@ export interface ModifiersModel {
   unitGroupBonusAttack: number;
   unitGroupBonusDefence: number;
 
+  // to be implemented
+  lifesteal: number;
+
+  // to be implemented
   resistAll: number;
 
   /* unit speed bonus */

--- a/src/app/core/modifiers/modifiers.ts
+++ b/src/app/core/modifiers/modifiers.ts
@@ -1,10 +1,10 @@
-import { UnitGroupInstModel } from '../unit-types/types';
+import { UnitGroup } from '../unit-types/types';
 import { KeysMatching } from '../utils';
 
 
 export interface ConditionalModifierParamsModel {
   // attacker: UnitGroupInstModel;
-  attacked: UnitGroupInstModel;
+  attacked: UnitGroup;
 }
 
 export interface ModifiersModel {

--- a/src/app/core/modifiers/mods-group.ts
+++ b/src/app/core/modifiers/mods-group.ts
@@ -40,6 +40,14 @@ export class ModsRefsGroup {
     return new ModsRefsGroup();
   }
 
+  static withRefs(modRefs: ModsRef[]): ModsRefsGroup {
+    const newGroup = new ModsRefsGroup();
+
+    modRefs.forEach(modRef => newGroup.addModsRef(modRef));
+
+    return newGroup;
+  }
+
   getCalcNumModValue<K extends NumModNames>(modName: K): number | null {
     const refsWithNumericMod = this.modsRefs.filter(modsRef => modsRef.hasMod(modName));
 

--- a/src/app/core/players/types.ts
+++ b/src/app/core/players/types.ts
@@ -1,26 +1,55 @@
+import { GameObject } from '../game-objects';
 import { Hero } from '../heroes';
 import { ResourcesModel } from '../resources';
-import { UnitGroupModel } from '../unit-types';
+import { UnitGroup } from '../unit-types';
 
 export enum PlayerTypeEnum {
   Player = 'Player',
   AI = 'AI',
 }
 
-/* todo: seems reasonable to have heroes and players models as well */
-export interface PlayerModel {
+export enum PlayerState {
+  /* player makes his move */
+  Normal = 'normal',
+
+  /* player targets a spell */
+  SpellTargeting = 'spell-targeting',
+
+  /* enemy now makes his turn, player waits */
+  WaitsForTurn = 'waits-for-turn',
+}
+
+export interface PlayerCreationModel {
   color: string;
 
-  /* resources can be stored separately in theory. */
   resources: ResourcesModel;
 
   type: PlayerTypeEnum;
 
   hero: Hero;
 
-  unitGroups: UnitGroupModel[];
+  unitGroups: UnitGroup[];
 }
 
-export interface PlayerInstanceModel extends PlayerModel {
-  id: string;
+export class Player extends GameObject<PlayerCreationModel> {
+  public static readonly categoryId: string = 'player';
+
+  public color!: string;
+
+  /* resources can be stored separately in theory. */
+  public resources!: ResourcesModel;
+
+  public type!: PlayerTypeEnum;
+
+  public hero!: Hero;
+
+  public unitGroups!: UnitGroup[];
+
+  create({ color, hero, resources, type, unitGroups }: PlayerCreationModel): void {
+    this.color = color;
+    this.resources = resources;
+    this.type = type;
+    this.unitGroups = unitGroups;
+    this.hero = hero;
+  }
 }

--- a/src/app/core/spells/common/blindness.ts
+++ b/src/app/core/spells/common/blindness.ts
@@ -1,7 +1,7 @@
 import { spellDescrElem } from '../../ui';
-import { SpellModel, SpellActivationType } from '../types';
+import { SpellBaseType, SpellActivationType } from '../types';
 
-export const BlindnessSpell: SpellModel = {
+export const BlindnessSpell: SpellBaseType = {
   name: 'Blindness',
   activationType: SpellActivationType.Instant,
   icon: {

--- a/src/app/core/spells/common/corrosive-fog.ts
+++ b/src/app/core/spells/common/corrosive-fog.ts
@@ -1,7 +1,7 @@
 import { EffectAnimation } from '../../api/vfx-api';
 import { spellDescrElem, strPercent } from '../../ui';
 import { createAnimation, getIconElement, getPlainBlurFrames, getReversePulseKeyframes } from '../../vfx';
-import { SpellActivationType, SpellModel } from '../types';
+import { SpellActivationType, SpellBaseType } from '../types';
 import { canActivateOnEnemyFn, debuffColors } from '../utils';
 
 const damageReduction = 0.14;
@@ -74,7 +74,7 @@ const CorrosiveFogAnimation: EffectAnimation = createAnimation([
 ]);
 
 
-export const CorrosiveFogDebuff: SpellModel<undefined | { debuffRoundsLeft: number }> = {
+export const CorrosiveFogDebuff: SpellBaseType<undefined | { debuffRoundsLeft: number }> = {
   name: 'Corrosion',
   activationType: SpellActivationType.Debuff,
   icon: {
@@ -133,7 +133,7 @@ export const CorrosiveFogDebuff: SpellModel<undefined | { debuffRoundsLeft: numb
   }
 };
 
-export const CorrosiveFogSpell: SpellModel = {
+export const CorrosiveFogSpell: SpellBaseType = {
   name: 'Corrosive Fog',
   activationType: SpellActivationType.Target,
   icon: {

--- a/src/app/core/spells/common/enchant.ts
+++ b/src/app/core/spells/common/enchant.ts
@@ -1,11 +1,11 @@
 import { spellDescrElem } from '../../ui';
 import { EnchantAnimation } from '../../vfx';
-import { SpellActivationType, SpellModel } from '../types';
+import { SpellActivationType, SpellBaseType } from '../types';
 import { canActivateOnEnemyFn, debuffColors } from '../utils';
 
 const damageIncreasePercent = 17;
 
-export const EnchantBuff: SpellModel = {
+export const EnchantBuff: SpellBaseType = {
   name: 'Enchanted',
   activationType: SpellActivationType.Debuff,
   icon: {
@@ -44,7 +44,7 @@ export const EnchantBuff: SpellModel = {
   },
 };
 
-export const EnchantSpell: SpellModel = {
+export const EnchantSpell: SpellBaseType = {
   name: 'Enchant',
   activationType: SpellActivationType.Target,
   icon: {

--- a/src/app/core/spells/common/firebird-heal.ts
+++ b/src/app/core/spells/common/firebird-heal.ts
@@ -1,7 +1,7 @@
 import { EffectAnimation } from '../../api/vfx-api';
 import { spellDescrElem } from '../../ui';
 import { createAnimation, getHealParts, getIconElement, getPlainAppearanceFrames, getPlainBlurFrames, getReversePulseKeyframes } from '../../vfx';
-import { SpellActivationType, SpellModel } from '../types';
+import { SpellActivationType, SpellBaseType } from '../types';
 import { canActivateOnAllyFn } from '../utils';
 
 // Theoretically, I can increase heal value along with manacost
@@ -46,7 +46,7 @@ const HealAnimation: EffectAnimation = createAnimation([
 /* Maybe make it ranged */
 const healPerBird = 17;
 
-export const FirebirdHealSpell: SpellModel = {
+export const FirebirdHealSpell: SpellBaseType = {
   name: 'Heal',
   activationType: SpellActivationType.Target,
   icon: {

--- a/src/app/core/spells/common/fright.ts
+++ b/src/app/core/spells/common/fright.ts
@@ -1,13 +1,13 @@
 import { spellDescrElem } from '../../ui';
-import { UnitGroupInstModel } from '../../unit-types';
+import { UnitGroup } from '../../unit-types';
 import { FrightAnimation } from '../../vfx';
-import { SpellActivationType, SpellModel } from '../types';
+import { SpellActivationType, SpellBaseType } from '../types';
 import { debuffColors } from '../utils';
 
 const damageDecreasePercent = 0.25;
 const uiPercent = damageDecreasePercent * 100;
 
-export const FrightSpellDebuff: SpellModel<{ frighter: UnitGroupInstModel }> = {
+export const FrightSpellDebuff: SpellBaseType<{ frighter: UnitGroup }> = {
   name: 'Fright',
   activationType: SpellActivationType.Debuff,
   icon: {
@@ -54,7 +54,7 @@ export const FrightSpellDebuff: SpellModel<{ frighter: UnitGroupInstModel }> = {
   },
 };
 
-export const FrightSpell: SpellModel = {
+export const FrightSpell: SpellBaseType = {
   name: 'Fright',
   activationType: SpellActivationType.Passive,
   icon: {

--- a/src/app/core/spells/common/frost-arrow.ts
+++ b/src/app/core/spells/common/frost-arrow.ts
@@ -2,7 +2,7 @@ import { DamageType } from '../../api/combat-api';
 import { EffectAnimation } from '../../api/vfx-api';
 import { spellDescrElem } from '../../ui';
 import { createAnimation, getDamageParts, getIconElement, getPlainAppearanceFrames, getPlainBlurFrames, getReversePulseKeyframes } from '../../vfx';
-import { SpellActivationType, SpellModel } from '../types';
+import { SpellActivationType, SpellBaseType } from '../types';
 import { canActivateOnEnemyFn, debuffColors } from '../utils';
 
 const icon = 'frost-emblem';
@@ -47,7 +47,7 @@ const magicDamage = 40;
 const slow = 4;
 const attackPenalty = 3;
 
-export const FrozenArrowDebuff: SpellModel = {
+export const FrozenArrowDebuff: SpellBaseType = {
   name: 'Freeze',
   activationType: SpellActivationType.Debuff,
   icon: {
@@ -89,7 +89,7 @@ export const FrozenArrowDebuff: SpellModel = {
   },
 };
 
-export const FrostArrowSpell: SpellModel = {
+export const FrostArrowSpell: SpellBaseType = {
   name: 'Frost Arrow',
   activationType: SpellActivationType.Target,
   icon: {

--- a/src/app/core/spells/common/haste.ts
+++ b/src/app/core/spells/common/haste.ts
@@ -1,7 +1,7 @@
 import { EffectAnimation } from '../../api/vfx-api';
 import { spellDescrElem } from '../../ui';
 import { createAnimation, getIconElement, getPlainAppearanceFrames, getPlainBlurFrames, getReversePulseKeyframes } from '../../vfx';
-import { SpellActivationType, SpellModel } from '../types';
+import { SpellActivationType, SpellBaseType } from '../types';
 import { buffColors, canActivateOnAllyFn } from '../utils';
 
 const icon = 'boot-stomp';
@@ -45,7 +45,7 @@ const HasteAnimation: EffectAnimation = createAnimation([
 const speedBonus = 5;
 
 
-export const HasteBuff: SpellModel = {
+export const HasteBuff: SpellBaseType = {
   name: 'Haste',
   activationType: SpellActivationType.Buff,
   icon: {
@@ -84,7 +84,7 @@ export const HasteBuff: SpellModel = {
   },
 };
 
-export const HasteSpell: SpellModel = {
+export const HasteSpell: SpellBaseType = {
   name: 'Haste',
   activationType: SpellActivationType.Target,
   icon: {

--- a/src/app/core/spells/common/heal.ts
+++ b/src/app/core/spells/common/heal.ts
@@ -1,6 +1,6 @@
 import { EffectAnimation } from '../../api/vfx-api';
 import { createAnimation, getHealParts, getIconElement, getPlainAppearanceFrames, getPlainBlurFrames, getReversePulseKeyframes } from '../../vfx';
-import { SpellActivationType, SpellModel } from '../types';
+import { SpellActivationType, SpellBaseType } from '../types';
 import { canActivateOnAllyFn } from '../utils';
 
 const icon = 'hospital-cross';
@@ -42,7 +42,7 @@ const HealAnimation: EffectAnimation = createAnimation([
 ]);
 
 
-export const HealSpell: SpellModel = {
+export const HealSpell: SpellBaseType = {
   name: 'Heal',
   activationType: SpellActivationType.Target,
   icon: {

--- a/src/app/core/spells/common/kneeling-light.ts
+++ b/src/app/core/spells/common/kneeling-light.ts
@@ -1,13 +1,13 @@
 import { Modifiers } from '../../modifiers';
 import { spellDescrElem } from '../../ui';
 import { frontStackingBuffAnimation } from '../../vfx';
-import { SpellActivationType, SpellModel } from '../types';
+import { SpellActivationType, SpellBaseType } from '../types';
 import { canActivateOnEnemyFn, debuffColors } from '../utils';
 
 const slowingPercent = 50;
 const spellIcon = 'player-despair';
 
-export const KneelingLightDebuff: SpellModel = {
+export const KneelingLightDebuff: SpellBaseType = {
   name: 'Slowed',
   activationType: SpellActivationType.Debuff,
   icon: {
@@ -50,7 +50,7 @@ export const KneelingLightDebuff: SpellModel = {
   },
 };
 
-export const KneelingLight: SpellModel = {
+export const KneelingLight: SpellBaseType = {
   name: 'Kneeling Light',
   icon: {
     // iconClr: 'rgb(235 142 178)',

--- a/src/app/core/spells/common/meteor.ts
+++ b/src/app/core/spells/common/meteor.ts
@@ -2,12 +2,12 @@ import { DamageType } from '../../api/combat-api';
 import { spellDescrElem } from '../../ui';
 import { CommonUtils } from '../../unit-types';
 import { simpleConvergentBuffAnimation, getDamageParts } from '../../vfx';
-import { SpellActivationType, SpellModel } from '../types';
+import { SpellActivationType, SpellBaseType } from '../types';
 
 const minDamage = 82;
 const maxDamage = 124;
 
-export const MeteorSpell: SpellModel = {
+export const MeteorSpell: SpellBaseType = {
   name: 'Meteor',
   activationType: SpellActivationType.Instant,
   icon: {

--- a/src/app/core/spells/common/poison-cloud.ts
+++ b/src/app/core/spells/common/poison-cloud.ts
@@ -3,7 +3,7 @@ import { EffectAnimation } from '../../api/vfx-api';
 import { spellDescrElem } from '../../ui';
 import { CommonUtils } from '../../unit-types';
 import { createAnimation, getDamageParts, getIconElement, getPlainBlurFrames, getReversePulseKeyframes } from '../../vfx';
-import { SpellActivationType, SpellModel } from '../types';
+import { SpellActivationType, SpellBaseType } from '../types';
 import { canActivateOnEnemyFn, debuffColors } from '../utils';
 
 /* In general.. this skill might reduce speed. Or maybe even a chance to skip attack */
@@ -80,7 +80,7 @@ const PoisonCloudAnimation: EffectAnimation = createAnimation([
 ]);
 
 
-export const PoisonCloudDebuff: SpellModel<undefined | { debuffRoundsLeft: number }> = {
+export const PoisonCloudDebuff: SpellBaseType<undefined | { debuffRoundsLeft: number }> = {
   name: 'Poisoned',
   activationType: SpellActivationType.Debuff,
   icon: {
@@ -151,7 +151,7 @@ export const PoisonCloudDebuff: SpellModel<undefined | { debuffRoundsLeft: numbe
   }
 };
 
-export const PoisonCloudSpell: SpellModel = {
+export const PoisonCloudSpell: SpellBaseType = {
   name: 'Poison Cloud',
   activationType: SpellActivationType.Target,
   icon: {

--- a/src/app/core/spells/common/rain-of-fire.ts
+++ b/src/app/core/spells/common/rain-of-fire.ts
@@ -1,12 +1,12 @@
 import { DamageType } from '../../api/combat-api';
 import { spellDescrElem } from '../../ui';
 import { FireAnimation, getDamageParts } from '../../vfx';
-import { SpellActivationType, SpellModel } from '../types';
+import { SpellActivationType, SpellBaseType } from '../types';
 import { canActivateOnEnemyFn } from '../utils';
 
 const baseDamage = 65;
 
-export const RainOfFireSpell: SpellModel = {
+export const RainOfFireSpell: SpellBaseType = {
   name: 'Rain of Fire',
   activationType: SpellActivationType.Target,
   icon: {

--- a/src/app/core/spells/common/summon-fire-spirits.ts
+++ b/src/app/core/spells/common/summon-fire-spirits.ts
@@ -1,11 +1,11 @@
 import { neutralsFraction } from '../../fractions/neutrals/fraction';
 import { spellDescrElem } from '../../ui';
 import { FireAnimation } from '../../vfx';
-import { SpellActivationType, SpellModel } from '../types';
+import { SpellActivationType, SpellBaseType } from '../types';
 
 const unitCount = 4;
 
-export const SummonFireSpiritsSpell: SpellModel = {
+export const SummonFireSpiritsSpell: SpellBaseType = {
   name: 'Summon Fire Spirits',
   activationType: SpellActivationType.Instant,
   icon: {

--- a/src/app/core/spells/common/summon-sagittar.ts
+++ b/src/app/core/spells/common/summon-sagittar.ts
@@ -1,11 +1,11 @@
 import { constellationFraction } from '../../fractions/constellation/fraction';
 import { spellDescrElem } from '../../ui';
 import { FireAnimation, simpleConvergentBuffAnimation } from '../../vfx';
-import { SpellActivationType, SpellModel } from '../types';
+import { SpellActivationType, SpellBaseType } from '../types';
 
 const unitCount = 4;
 
-export const SummonSagittarSpell: SpellModel = {
+export const SummonSagittarSpell: SpellBaseType = {
   name: 'Summon Sagittar',
   activationType: SpellActivationType.Instant,
   icon: {

--- a/src/app/core/spells/common/wind-bless.ts
+++ b/src/app/core/spells/common/wind-bless.ts
@@ -1,18 +1,18 @@
 import { Colors } from '../../assets';
 import { Modifiers } from '../../modifiers';
 import { spellPlainDescription } from '../../ui';
-import { UnitGroupInstModel } from '../../unit-types';
-import { SpellActivationType, SpellModel } from '../types';
+import { UnitGroup } from '../../unit-types';
+import { SpellActivationType, SpellBaseType } from '../types';
 
 type State = {
   roundsLeft: number,
-  target: UnitGroupInstModel,
+  target: UnitGroup,
   mods: Modifiers,
 };
 
 const attackBonus = 2;
 
-export const WindBlessBuff: SpellModel<State> = {
+export const WindBlessBuff: SpellBaseType<State> = {
   name: 'Wind Bless',
   icon: {
     icon: 'feather-wing',

--- a/src/app/core/spells/spell-events.ts
+++ b/src/app/core/spells/spell-events.ts
@@ -1,19 +1,19 @@
 import { EventHandlersMap, EventNames, EventTypeByName, createEventType, createEventsGroup } from 'src/app/store';
-import { PlayerInstanceModel } from '../players';
-import { UnitGroupInstModel } from '../unit-types';
-import { SpellInstance } from './types';
+import { Player } from '../players';
+import { UnitGroup } from '../unit-types';
+import { Spell } from './types';
 
 
 export const SpellEventsGroup = createEventsGroup({
   prefix: 'Spells',
   events: {
-    PlayerTargetsSpell: createEventType<{ target: UnitGroupInstModel }>(''),
-    SpellPlacedOnUnitGroup: createEventType<{ target: UnitGroupInstModel }>(''),
+    PlayerTargetsSpell: createEventType<{ target: UnitGroup }>(''),
+    SpellPlacedOnUnitGroup: createEventType<{ target: UnitGroup }>(''),
     NewRoundBegins: createEventType<{ round: number }>(''),
-    PlayerCastsInstantSpell: createEventType<{ player: PlayerInstanceModel, spell: SpellInstance }>(''),
+    PlayerCastsInstantSpell: createEventType<{ player: Player, spell: Spell }>(''),
     UnitGroupAttacks: createEventType<{
-      attacker: UnitGroupInstModel;
-      attacked: UnitGroupInstModel;
+      attacker: UnitGroup;
+      attacked: UnitGroup;
     }>(''),
   },
 });

--- a/src/app/core/spells/types.ts
+++ b/src/app/core/spells/types.ts
@@ -1,11 +1,12 @@
 import { CombatActionsRef } from '../api/combat-api';
 import { VfxApi } from '../api/vfx-api';
 import { Icon } from '../assets';
+import { GameObject } from '../game-objects';
 import { Hero } from '../heroes';
-import { ItemInstanceModel } from '../items';
-import { PlayerInstanceModel } from '../players';
+import { ItemObject } from '../items';
+import { Player } from '../players';
 import { DescriptionElement } from '../ui/descriptions';
-import { UnitGroupInstModel } from '../unit-types';
+import { UnitGroup } from '../unit-types';
 import { SpellEventHandlers } from './spell-events';
 
 export enum SpellActivationType {
@@ -19,15 +20,13 @@ export enum SpellActivationType {
   Buff = 'buff',
 }
 
-/* Spell model */
-
 export type DefaultSpellStateType = unknown;
 
 export interface SpellDescriptionData<SpellStateType = DefaultSpellStateType> {
-  thisSpell: SpellModel<SpellStateType>;
-  spellInstance: SpellInstance<SpellStateType>;
-  ownerPlayer: PlayerInstanceModel;
-  ownerUnit?: UnitGroupInstModel;
+  thisSpell: SpellBaseType<SpellStateType>;
+  spellInstance: Spell<SpellStateType>;
+  ownerPlayer: Player;
+  ownerUnit?: UnitGroup;
   ownerHero: Hero;
 }
 
@@ -35,7 +34,7 @@ export interface SpellDescription {
   descriptions: DescriptionElement[]
 }
 
-export interface SpellModel<SpellStateType = DefaultSpellStateType> {
+export interface SpellBaseType<SpellStateType = DefaultSpellStateType> {
   name: string;
   // level: number;
   activationType: SpellActivationType;
@@ -45,29 +44,12 @@ export interface SpellModel<SpellStateType = DefaultSpellStateType> {
 
   getDescription(data: SpellDescriptionData<SpellStateType>): { descriptions: DescriptionElement[] };
 
-  type: SpellTypeModel<SpellStateType>;
+  type: SpellTypeConfig<SpellStateType>;
 
   icon: Icon;
 }
 
-export interface SpellInstance<T = DefaultSpellStateType> {
-  name: string;
-  description: string;
-
-  state: T | null;
-  currentLevel: number;
-  currentManaCost: number;
-  // cooldown: number;
-
-
-  baseType: SpellModel<T>;
-
-  sourceInfo: {
-    item?: ItemInstanceModel,
-  };
-}
-
-export interface SpellTypeModel<SpellStateType> {
+export interface SpellTypeConfig<SpellStateType> {
   spellConfig: SpellConfig<SpellStateType>;
   spellInfo: { name: string; };
 }
@@ -79,24 +61,58 @@ export interface SpellCombatEventsRef {
 export interface SpellCombatRefsModel<SpellStateType> {
   events: SpellCombatEventsRef;
   actions: CombatActionsRef;
-  thisSpell: SpellModel<SpellStateType>;
-  spellInstance: SpellInstance<SpellStateType>;
-  ownerPlayer: PlayerInstanceModel;
-  ownerUnit?: UnitGroupInstModel;
+  thisSpell: SpellBaseType<SpellStateType>;
+  spellInstance: Spell<SpellStateType>;
+  ownerPlayer: Player;
+  ownerUnit?: UnitGroup;
   ownerHero: Hero;
   vfx: VfxApi;
 }
 
 export interface CanActivateSpellParams {
-  unitGroup: UnitGroupInstModel,
+  unitGroup: UnitGroup,
   isEnemy: boolean,
 }
 
 export interface SpellConfig<SpellStateType> {
   init: (combatRefs: SpellCombatRefsModel<SpellStateType>) => void;
-  getManaCost: (spellInst: SpellInstance<SpellStateType>) => number;
+  getManaCost: (spellInst: Spell<SpellStateType>) => number;
   targetCastConfig?: {
     canActivate?: (info: CanActivateSpellParams) => boolean,
   };
+}
+
+export interface SpellCreationParams<T> {
+  spellBaseType: SpellBaseType<T>;
+  initialLevel: number;
+  state?: T;
+}
+
+export class Spell<T = DefaultSpellStateType> extends GameObject<SpellCreationParams<T>> {
+  public static readonly categoryId: string = 'spell';
+
+  public name!: string;
+
+  public state?: T;
+  public currentLevel: number = 1;
+  public currentManaCost!: number;
+  // cooldown: number;
+
+  public baseType!: SpellBaseType<T>;
+
+  public sourceInfo!: {
+    item?: ItemObject,
+  };
+
+  create({ spellBaseType, initialLevel, state }: SpellCreationParams<T>): void {
+    this.baseType = spellBaseType;
+
+    this.currentLevel = initialLevel;
+    this.name = this.baseType.type.spellInfo.name;
+    this.state = state;
+    this.sourceInfo = {};
+
+    this.currentManaCost = this.baseType.type.spellConfig.getManaCost(this);
+  }
 }
 

--- a/src/app/core/spells/types.ts
+++ b/src/app/core/spells/types.ts
@@ -3,7 +3,7 @@ import { VfxApi } from '../api/vfx-api';
 import { Icon } from '../assets';
 import { GameObject } from '../game-objects';
 import { Hero } from '../heroes';
-import { ItemObject } from '../items';
+import { Item } from '../items';
 import { Player } from '../players';
 import { DescriptionElement } from '../ui/descriptions';
 import { UnitGroup } from '../unit-types';
@@ -101,7 +101,7 @@ export class Spell<T = DefaultSpellStateType> extends GameObject<SpellCreationPa
   public baseType!: SpellBaseType<T>;
 
   public sourceInfo!: {
-    item?: ItemObject,
+    item?: Item,
   };
 
   create({ spellBaseType, initialLevel, state }: SpellCreationParams<T>): void {

--- a/src/app/core/spells/utils.ts
+++ b/src/app/core/spells/utils.ts
@@ -2,9 +2,9 @@ import { CombatActionsRef, PostDamageInfo } from '../api/combat-api';
 import { VfxApi } from '../api/vfx-api';
 import { Colors } from '../assets';
 import { Hero } from '../heroes';
-import { UnitBase, UnitGroupInstModel } from '../unit-types';
+import { UnitBaseType, UnitGroup } from '../unit-types';
 import { getDamageParts } from '../vfx';
-import { CanActivateSpellParams, SpellInstance, SpellModel } from './types';
+import { CanActivateSpellParams, Spell, SpellBaseType } from './types';
 
 export const canActivateOnEnemyFn = ({ isEnemy, unitGroup }: CanActivateSpellParams): boolean => {
   return isEnemy && unitGroup.fightInfo.isAlive;
@@ -31,7 +31,7 @@ export const logDamage = ({
   targetUnit,
   thisSpell,
   vfx
-}: { actionInfo: PostDamageInfo, ownerHero: Hero, targetUnit: UnitGroupInstModel, thisSpell: SpellModel, actions: CombatActionsRef, vfx: VfxApi }) => {
+}: { actionInfo: PostDamageInfo, ownerHero: Hero, targetUnit: UnitGroup, thisSpell: SpellBaseType, actions: CombatActionsRef, vfx: VfxApi }) => {
   actions.historyLog(`${ownerHero.name} deals ${actionInfo.finalDamage} damage to ${targetUnit.type.name} with ${thisSpell.name}`)
 
   vfx.createFloatingMessageForUnitGroup(

--- a/src/app/core/towns/types.ts
+++ b/src/app/core/towns/types.ts
@@ -1,5 +1,7 @@
 import { Resources } from '../resources';
-import { UnitBase } from '../unit-types';
+import { UnitBaseType } from '../unit-types';
+
+// Towns and buildings, practically, can also become GameObjects.
 
 export enum ActivityTypes {
   Hiring,
@@ -10,7 +12,7 @@ interface BuildingAcitivty<T extends ActivityTypes = ActivityTypes> {
 }
 
 export interface HiringDetails {
-  type: UnitBase;
+  type: UnitBaseType;
   growth: number;
   // optional, default is 7
   refillDaysInterval?: number;

--- a/src/app/core/ui/action-hint.ts
+++ b/src/app/core/ui/action-hint.ts
@@ -1,6 +1,6 @@
 import { SafeHtml } from '@angular/platform-browser';
-import { SpellInstance } from 'src/app/core/spells';
-import { UnitGroupModel, UnitGroupInstModel } from 'src/app/core/unit-types';
+import { Spell } from 'src/app/core/spells';
+import { UnitGroup } from 'src/app/core/unit-types';
 
 export enum ActionHintTypeEnum {
   OnHoverEnemyCard = 'on-hover-enemy-card',
@@ -18,7 +18,7 @@ export interface CustomHtmlActionHint extends ActionHintModel<ActionHintTypeEnum
 }
 
 export interface AttackActionHintInfo extends ActionHintModel<ActionHintTypeEnum.OnHoverEnemyCard> {
-  attackedGroup: UnitGroupModel;
+  attackedGroup: UnitGroup;
   minDamage: number;
   maxDamage: number;
   minCountLoss: number;
@@ -29,7 +29,7 @@ export interface AttackActionHintInfo extends ActionHintModel<ActionHintTypeEnum
 }
 
 export interface SpellTargetActionHint extends ActionHintModel<ActionHintTypeEnum.OnTargetSpell> {
-  spell: SpellInstance;
-  target: UnitGroupInstModel;
+  spell: Spell;
+  target: UnitGroup;
 }
 

--- a/src/app/core/ui/battle-log.ts
+++ b/src/app/core/ui/battle-log.ts
@@ -1,5 +1,5 @@
-import { PlayerModel } from 'src/app/core/players';
-import { UnitBase } from 'src/app/core/unit-types';
+import { UnitBaseType } from 'src/app/core/unit-types';
+import { Player } from '../players';
 
 
 export enum HistoryLogTypesEnum {
@@ -21,10 +21,10 @@ export interface RoundInfoMessage extends HistoryLogModel<HistoryLogTypesEnum.Ro
 }
 
 export interface DealtDamageMessage extends HistoryLogModel<HistoryLogTypesEnum.DealtDamageMsg> {
-  attackingPlayer: PlayerModel;
-  attackedPlayer: PlayerModel;
-  attacker: UnitBase;
-  attacked: UnitBase;
+  attackingPlayer: Player;
+  attackedPlayer: Player;
+  attacker: UnitBaseType;
+  attacked: UnitBaseType;
   attackersNumber: number;
   attackedNumber: number;
   losses: number;

--- a/src/app/core/ui/descriptions/items.ts
+++ b/src/app/core/ui/descriptions/items.ts
@@ -1,4 +1,4 @@
-import type { ItemInstanceModel } from '../../items';
+import type { ItemObject } from '../../items';
 import { modsFormatters } from '../../modifiers';
 import { DescHtmlElement, DescriptionElementType } from './types';
 
@@ -7,7 +7,7 @@ function getItemModHtmlElem(text: string): string {
 }
 
 
-export function itemStatsDescr(item: ItemInstanceModel): DescHtmlElement {
+export function itemStatsDescr(item: ItemObject): DescHtmlElement {
   const itemStaticMods = item.baseType.staticMods;
 
   const mods = Object.entries(itemStaticMods).map(([modName, modValue]) => {

--- a/src/app/core/ui/descriptions/items.ts
+++ b/src/app/core/ui/descriptions/items.ts
@@ -1,4 +1,4 @@
-import type { ItemObject } from '../../items';
+import type { Item } from '../../items';
 import { modsFormatters } from '../../modifiers';
 import { DescHtmlElement, DescriptionElementType } from './types';
 
@@ -7,7 +7,7 @@ function getItemModHtmlElem(text: string): string {
 }
 
 
-export function itemStatsDescr(item: ItemObject): DescHtmlElement {
+export function itemStatsDescr(item: Item): DescHtmlElement {
   const itemStaticMods = item.baseType.staticMods;
 
   const mods = Object.entries(itemStaticMods).map(([modName, modValue]) => {

--- a/src/app/core/ui/popup.ts
+++ b/src/app/core/ui/popup.ts
@@ -1,8 +1,8 @@
-import { NeutralCampStructure, NeutralSite, ResourceRewardModel } from 'src/app/core/structures';
-import { UnitBase } from 'src/app/core/unit-types';
+import { ResourceRewardModel, StructureModel } from 'src/app/core/structures';
+import { UnitBaseType } from 'src/app/core/unit-types';
 
 export interface LossModel {
-  type: UnitBase;
+  type: UnitBaseType;
   count: number;
 };
 
@@ -10,35 +10,35 @@ export interface FightEndsPopup {
   isWin: boolean;
   playerLosses: LossModel[];
   enemyLosses: LossModel[];
-  struct: NeutralCampStructure;
+  struct: StructureModel;
 }
 
 export interface StructRewardPopup {
-  struct: NeutralCampStructure;
+  struct: StructureModel;
   selectedRewardGroup?: ResourceRewardModel[];
 }
 
 /* some of these can be united */
 export interface StructHireRewardPopup {
-  struct: NeutralCampStructure;
+  struct: StructureModel;
 }
 
 export interface StructItemRewardPopup {
-  struct: NeutralCampStructure;
+  struct: StructureModel;
 }
 
 export interface PrefightPopup {
-  struct: NeutralCampStructure;
+  struct: StructureModel;
 }
 
 export interface PreviewPopup {
-  struct: NeutralSite;
+  struct: StructureModel;
 }
 
 export interface UpgradingPopup {
-  struct: NeutralSite;
+  struct: StructureModel;
 }
 
 export interface ScriptedRewardPopup {
-  struct: NeutralCampStructure;
+  struct: StructureModel;
 }

--- a/src/app/core/unit-types/neutrals/units.ts
+++ b/src/app/core/unit-types/neutrals/units.ts
@@ -1,14 +1,14 @@
 import { AssetsImages } from '../../assets';
 import { neutralsFraction } from '../../fractions/neutrals/fraction';
 import { FrightSpell } from '../../spells/common';
-import { UnitBase } from '../types';
+import { UnitBaseType } from '../types';
 import { createStats } from '../utils';
 
 /*
   Theoretically, I can set default values for some params when creating fraction.
   Also, there might be some batch creation, like 'defineUnitTypes'
  */
-const Wraiths: UnitBase = neutralsFraction.defineUnitType('SupremeGhosts', {
+const Wraiths: UnitBaseType = neutralsFraction.defineUnitType('SupremeGhosts', {
   mainPortraitUrl: AssetsImages.Melee,
   name: 'Wraiths',
   level: 1,

--- a/src/app/core/unit-types/types.ts
+++ b/src/app/core/unit-types/types.ts
@@ -28,12 +28,15 @@ export interface UnitTypeBaseStatsModel {
   health: number;
   /* base speed of this unit type. speed defines how early in the battle order can be placed */
   speed: number;
-  /* base defence of this unit type, each 15 poins of defense increase EHP by 100% */
-  /* maybe defence types can be different, although I don't really think I want to have
-      paper-rock-scissors here  */
+
+  /**
+   * Similar to Homm3 system.
+   *  When attacking, your attack is checked against enemy defence.
+   *  If attack is higher than defence, damage is increased by 5% per each point of difference.
+   *  If lower, damage is decreased by 3% percent of difference.
+   */
   defence: number;
 
-  /* Similar to Homm3 system, where each point of difference between attack/defence increases damage by 5 percent */
   attackRating: number;
 
   damageInfo: UnitDamageModel;
@@ -64,9 +67,6 @@ export interface UnitBaseType {
   defaultModifiers?: Modifiers;
 
   defaultSpells?: SpellBaseType[];
-  /* create a separate mapping, table UnitGroup->Abilities */
-  /*  Associative tables.. can be useful. Don't need to overgrow the model */
-  // baseAbilities?: AbilityModel[];
 
   /* minimal amount of units that can stack can be hired, sold or split by */
   minQuantityPerStack: number;
@@ -81,16 +81,6 @@ export interface UnitBaseType {
     upgradeCost: Partial<ResourcesModel>,
   };
 }
-
-// export interface UnitGroupInstModel extends UnitGroupModel {
-//   ownerPlayerRef: PlayerInstanceModel;
-
-//   spells: SpellInstance[];
-
-//   // Think, what it needs to be? should it be refs
-//   // And should all applied mods be stored here? feels like rather not...
-//   modifiers: Modifiers[];
-// }
 
 interface UnitCreationParams {
   count: number;
@@ -111,18 +101,15 @@ export class UnitGroup extends GameObject<UnitCreationParams> {
   /* the last unit hp tail. If undefined, the tail unit hp is full */
   public tailUnitHp?: number;
 
-  /* not sure if this should be in this model, tbd later */
   public fightInfo!: {
     initialCount: number;
     isAlive: boolean;
     spellsOnCooldown?: boolean;
   };
-  // ownerPlayerRef: PlayerInstanceModel;
 
   public spells!: Spell[];
 
-  // Think, what it needs to be? should it be refs
-  // And should all applied mods be stored here? feels like rather not... or maybe yes.
+  // Should it be mod refs? or plain modifiers?
   public modifiers!: Modifiers[];
 
   create({ count, ownerPlayer, unitBase }: UnitCreationParams): void {

--- a/src/app/core/unit-types/utils.ts
+++ b/src/app/core/unit-types/utils.ts
@@ -1,8 +1,8 @@
-import { PlayerInstanceModel } from '../players';
-import { UnitBase, UnitGroupInstModel, UnitGroupModel, UnitTypeBaseStatsModel } from './types';
+import { Player } from '../players';
+import { UnitBaseType, UnitGroup, UnitTypeBaseStatsModel } from './types';
 
 /* unit type, minCount, maxCount, maxGroupsOfThisType */
-type UnitModel = [unitType: UnitBase, min: number, max: number, maxOfThisType: number | void];
+type UnitModel = [unitType: UnitBaseType, min: number, max: number, maxOfThisType: number | void];
 
 export interface GenerationModel {
   minUnitGroups: number;
@@ -61,15 +61,23 @@ export const CommonUtils = {
 };
 
 interface GenerationDescription {
-  unitType: UnitBase;
+  unitType: UnitBaseType;
   min: number;
   max: number;
   maxGroupsOfThisType: number;
   created: number;
 }
 
+// this should probably not generate units right away, maybe just create a model
+// basing on which army may be created.
+
+interface UnitGenerationModel {
+  count: number;
+  unitType: UnitBaseType;
+}
+
 export const UnitsUtils = {
-  createRandomArmy(options: GenerationModel): UnitGroupModel[] {
+  createRandomArmy(options: GenerationModel): UnitGenerationModel[] {
     const groupsToGenerateCount = CommonUtils.randIntInRange(options.minUnitGroups, options.maxUnitGroups);
     const generatedGroups = [];
     const unitsToGenerate = [...options.units];
@@ -96,14 +104,15 @@ export const UnitsUtils = {
       const unitType = unit.unitType;
 
       const count = CommonUtils.randIntInRange(unit.min, unit.max);
-      const newUnitGroup: UnitGroupModel = {
+      // problem
+      const newUnitGroup: UnitGenerationModel = {
         count: count,
-        type: unitType,
-        turnsLeft: unitType.defaultTurnsPerRound,
-        fightInfo: {
-          initialCount: count,
-          isAlive: true,
-        },
+        unitType,
+        // turnsLeft: unitType.defaultTurnsPerRound,
+        // fightInfo: {
+        // initialCount: count,
+        // isAlive: true,
+        // },
       };
 
       generatedGroups.push(newUnitGroup);
@@ -123,10 +132,10 @@ export const UnitsUtils = {
     return generatedGroups;
   },
 
-  createRandomArmyForPlayer(options: GenerationModel, player: PlayerInstanceModel): UnitGroupInstModel[] {
-    return this.createRandomArmy(options).map((unitGroup: UnitGroupModel) => {
-      unitGroup.ownerPlayerRef = player;
-      return unitGroup as UnitGroupInstModel;
-    });
-  }
+  // createRandomArmyForPlayer(options: GenerationModel, player: PlayerInstanceModel): UnitGroupInstModel[] {
+  // return this.createRandomArmy(options).map((unitGroup: UnitGroupInstModel) => {
+  // unitGroup.ownerPlayerRef = player;
+  // return unitGroup as UnitGroupInstModel;
+  // });/
+  // }
 }

--- a/src/app/core/unit-types/utils.ts
+++ b/src/app/core/unit-types/utils.ts
@@ -65,11 +65,8 @@ interface GenerationDescription {
   min: number;
   max: number;
   maxGroupsOfThisType: number;
-  created: number;
+  createdTimes: number;
 }
-
-// this should probably not generate units right away, maybe just create a model
-// basing on which army may be created.
 
 interface UnitGenerationModel {
   count: number;
@@ -89,7 +86,7 @@ export const UnitsUtils = {
         min,
         max,
         maxGroupsOfThisType,
-        created: 0,
+        createdTimes: 0,
       });
 
       return unitGroupsMap;
@@ -104,38 +101,25 @@ export const UnitsUtils = {
       const unitType = unit.unitType;
 
       const count = CommonUtils.randIntInRange(unit.min, unit.max);
-      // problem
+
       const newUnitGroup: UnitGenerationModel = {
         count: count,
         unitType,
-        // turnsLeft: unitType.defaultTurnsPerRound,
-        // fightInfo: {
-        // initialCount: count,
-        // isAlive: true,
-        // },
       };
 
       generatedGroups.push(newUnitGroup);
 
-      unit.created++;
+      unit.createdTimes++;
 
-      if (unit.created >= unit.maxGroupsOfThisType) {
+      if (unit.createdTimes >= unit.maxGroupsOfThisType) {
         console.log('this unit was generated max times')
         unitsMap.delete(randUnitDescr);
         CommonUtils.removeItem(unitsToGenerate, randUnitDescr)
       }
     }
 
-
     console.log('generated groups', generatedGroups);
 
     return generatedGroups;
   },
-
-  // createRandomArmyForPlayer(options: GenerationModel, player: PlayerInstanceModel): UnitGroupInstModel[] {
-  // return this.createRandomArmy(options).map((unitGroup: UnitGroupInstModel) => {
-  // unitGroup.ownerPlayerRef = player;
-  // return unitGroup as UnitGroupInstModel;
-  // });/
-  // }
 }

--- a/src/app/features/battleground/components/item-icon/item-icon.component.ts
+++ b/src/app/features/battleground/components/item-icon/item-icon.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core';
-import { ItemObject } from 'src/app/core/items';
+import { Item } from 'src/app/core/items';
 import { HintAttachment } from 'src/app/features/shared/components';
 
 @Component({
@@ -9,7 +9,7 @@ import { HintAttachment } from 'src/app/features/shared/components';
 })
 export class ItemIconComponent {
 
-  @Input() public item!: ItemObject;
+  @Input() public item!: Item;
   @Input() public hintPos!: HintAttachment;
 
   constructor() { }

--- a/src/app/features/battleground/components/item-icon/item-icon.component.ts
+++ b/src/app/features/battleground/components/item-icon/item-icon.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core';
-import { ItemInstanceModel } from 'src/app/core/items';
+import { ItemObject } from 'src/app/core/items';
 import { HintAttachment } from 'src/app/features/shared/components';
 
 @Component({
@@ -9,7 +9,7 @@ import { HintAttachment } from 'src/app/features/shared/components';
 })
 export class ItemIconComponent {
 
-  @Input() public item!: ItemInstanceModel;
+  @Input() public item!: ItemObject;
   @Input() public hintPos!: HintAttachment;
 
   constructor() { }

--- a/src/app/features/battleground/components/item-slot/item-slot.component.ts
+++ b/src/app/features/battleground/components/item-slot/item-slot.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnChanges } from '@angular/core';
 import { PlayerEquipsItem, PlayerUnequipsItem } from 'src/app/core/events';
 import { Hero } from 'src/app/core/heroes';
-import { ExtendedSlotType, InventoryItems, ItemObject, ItemSlotType } from 'src/app/core/items';
+import { ExtendedSlotType, InventoryItems, Item, ItemSlotType } from 'src/app/core/items';
 import { TypedChanges } from 'src/app/core/utils';
 import { MwPlayersService } from 'src/app/features/services';
 import { StoreClient } from 'src/app/store';
@@ -20,9 +20,9 @@ export class ItemSlotComponent extends StoreClient() implements OnChanges {
 
   public isEquipped: boolean = false;
 
-  public equippedItem: ItemObject | null = null;
+  public equippedItem: Item | null = null;
 
-  public availableItemsForSlot: ItemObject[] = [];
+  public availableItemsForSlot: Item[] = [];
 
   private hero: Hero = this.playersService.getCurrentPlayer().hero;
 
@@ -49,7 +49,7 @@ export class ItemSlotComponent extends StoreClient() implements OnChanges {
     }
   }
 
-  public equipItem(item: ItemObject<object>): void {
+  public equipItem(item: Item<object>): void {
     if (this.equippedItem === item) {
       return;
     }

--- a/src/app/features/battleground/components/item-slot/item-slot.component.ts
+++ b/src/app/features/battleground/components/item-slot/item-slot.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnChanges } from '@angular/core';
 import { PlayerEquipsItem, PlayerUnequipsItem } from 'src/app/core/events';
 import { Hero } from 'src/app/core/heroes';
-import { ExtendedSlotType, InventoryItems, ItemInstanceModel, ItemSlotType } from 'src/app/core/items';
+import { ExtendedSlotType, InventoryItems, ItemObject, ItemSlotType } from 'src/app/core/items';
 import { TypedChanges } from 'src/app/core/utils';
 import { MwPlayersService } from 'src/app/features/services';
 import { StoreClient } from 'src/app/store';
@@ -20,9 +20,9 @@ export class ItemSlotComponent extends StoreClient() implements OnChanges {
 
   public isEquipped: boolean = false;
 
-  public equippedItem: ItemInstanceModel | null = null;
+  public equippedItem: ItemObject | null = null;
 
-  public availableItemsForSlot: ItemInstanceModel[] = [];
+  public availableItemsForSlot: ItemObject[] = [];
 
   private hero: Hero = this.playersService.getCurrentPlayer().hero;
 
@@ -49,7 +49,7 @@ export class ItemSlotComponent extends StoreClient() implements OnChanges {
     }
   }
 
-  public equipItem(item: ItemInstanceModel<object>): void {
+  public equipItem(item: ItemObject<object>): void {
     if (this.equippedItem === item) {
       return;
     }

--- a/src/app/features/battleground/components/mw-battle-hero-abilities/mw-battle-hero-abilities.component.ts
+++ b/src/app/features/battleground/components/mw-battle-hero-abilities/mw-battle-hero-abilities.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
-import { PlayerInstanceModel } from 'src/app/core/players';
-import { SpellInstance } from 'src/app/core/spells';
-import { MwCurrentPlayerStateService, MwPlayersService, PlayerState } from 'src/app/features/services';
+import { Player, PlayerState } from 'src/app/core/players';
+import { Spell } from 'src/app/core/spells';
+import { MwCurrentPlayerStateService, MwPlayersService } from 'src/app/features/services';
 
 @Component({
   selector: 'mw-battle-hero-abilities',
@@ -10,14 +10,14 @@ import { MwCurrentPlayerStateService, MwPlayersService, PlayerState } from 'src/
 })
 export class MwBattleHeroAbilitiesComponent {
 
-  public currentPlayer: PlayerInstanceModel = this.players.getCurrentPlayer();
+  public currentPlayer: Player = this.players.getCurrentPlayer();
 
   constructor(
     private readonly players: MwPlayersService,
     public readonly curPlayerState: MwCurrentPlayerStateService,
   ) { }
 
-  public onAbilityClick(spell: SpellInstance) {
+  public onAbilityClick(spell: Spell) {
     if (spell.currentManaCost > this.currentPlayer.hero.stats.currentMana || this.curPlayerState.spellsAreOnCooldown) {
       return;
     }

--- a/src/app/features/battleground/components/mw-gameboard/mw-gameboard.component.ts
+++ b/src/app/features/battleground/components/mw-gameboard/mw-gameboard.component.ts
@@ -1,9 +1,9 @@
 import { AfterViewInit, ChangeDetectorRef, Component, OnInit, QueryList, ViewChildren } from '@angular/core';
 import { takeUntil } from 'rxjs/operators';
 import { GroupDamagedByGroup, GroupDamagedByGroupEvent, PlayerStartsFight, UnitSummoned, UnitSummonedEvent } from 'src/app/core/events';
-import { PlayerInstanceModel } from 'src/app/core/players';
+import { Player } from 'src/app/core/players';
 import { UnitsOrientation } from 'src/app/core/ui';
-import { UnitGroupInstModel } from 'src/app/core/unit-types';
+import { UnitGroup } from 'src/app/core/unit-types';
 import { getDamageParts } from 'src/app/core/vfx';
 import { BattleStateService, CombatInteractorService, MwCardsMappingService, MwNeutralPlayerService, MwPlayerStateService } from 'src/app/features/services';
 import { State } from 'src/app/features/services/state.service';
@@ -17,13 +17,13 @@ import { MwUnitGroupCardComponent } from '../mw-unit-group-card/mw-unit-group-ca
   styleUrls: ['./mw-gameboard.component.scss'],
 })
 export class MwGameboardComponent extends StoreClient() implements OnInit, AfterViewInit {
-  public mainPlayerUnitGroups!: UnitGroupInstModel[];
-  public neutralPlayerGroups!: UnitGroupInstModel[];
+  public mainPlayerUnitGroups!: UnitGroup[];
+  public neutralPlayerGroups!: UnitGroup[];
 
-  public mainPlayerInfo!: PlayerInstanceModel;
-  public enemyPlayerInfo!: PlayerInstanceModel;
+  public mainPlayerInfo!: Player;
+  public enemyPlayerInfo!: Player;
 
-  public fightQueue!: UnitGroupInstModel[];
+  public fightQueue!: UnitGroup[];
 
   @ViewChildren(MwUnitGroupCardComponent)
   public cards!: QueryList<MwUnitGroupCardComponent>;
@@ -56,7 +56,7 @@ export class MwGameboardComponent extends StoreClient() implements OnInit, After
     /* Rework this. Try to implement summons */
   }
 
-  public onGroupDies(unitGroup: UnitGroupInstModel): void {
+  public onGroupDies(unitGroup: UnitGroup): void {
     /* todo: questionable */
     this.cardsMapping.unregister(unitGroup);
   }
@@ -106,8 +106,8 @@ export class MwGameboardComponent extends StoreClient() implements OnInit, After
   }
 
   private updatePlayersUnitGroupsToShow(): void {
-    this.mainPlayerUnitGroups = this.mwBattleState.heroesUnitGroupsMap.get(this.mainPlayerInfo) as UnitGroupInstModel[];
-    this.neutralPlayerGroups = this.mwBattleState.heroesUnitGroupsMap.get(this.enemyPlayerInfo) as UnitGroupInstModel[];
+    this.mainPlayerUnitGroups = this.mwBattleState.heroesUnitGroupsMap.get(this.mainPlayerInfo) as UnitGroup[];
+    this.neutralPlayerGroups = this.mwBattleState.heroesUnitGroupsMap.get(this.enemyPlayerInfo) as UnitGroup[];
     this.updateFightQueue();
   }
 

--- a/src/app/features/battleground/components/mw-items-panel/mw-items-panel.component.ts
+++ b/src/app/features/battleground/components/mw-items-panel/mw-items-panel.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { ItemObject } from 'src/app/core/items';
+import { Item } from 'src/app/core/items';
 import { Player } from 'src/app/core/players';
 import { MwPlayersService } from 'src/app/features/services';
 
@@ -11,7 +11,7 @@ import { MwPlayersService } from 'src/app/features/services';
 export class MwItemsPanelComponent implements OnInit {
 
   public currentPlayer!: Player;
-  public equippedItems!: ItemObject[];
+  public equippedItems!: Item[];
 
   constructor(
     private readonly players: MwPlayersService,

--- a/src/app/features/battleground/components/mw-items-panel/mw-items-panel.component.ts
+++ b/src/app/features/battleground/components/mw-items-panel/mw-items-panel.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
-import { ItemInstanceModel } from 'src/app/core/items';
-import { PlayerInstanceModel } from 'src/app/core/players';
+import { ItemObject } from 'src/app/core/items';
+import { Player } from 'src/app/core/players';
 import { MwPlayersService } from 'src/app/features/services';
 
 @Component({
@@ -10,8 +10,8 @@ import { MwPlayersService } from 'src/app/features/services';
 })
 export class MwItemsPanelComponent implements OnInit {
 
-  public currentPlayer!: PlayerInstanceModel;
-  public equippedItems!: ItemInstanceModel[];
+  public currentPlayer!: Player;
+  public equippedItems!: ItemObject[];
 
   constructor(
     private readonly players: MwPlayersService,

--- a/src/app/features/battleground/components/mw-player-resources/mw-player-resources.component.ts
+++ b/src/app/features/battleground/components/mw-player-resources/mw-player-resources.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { PlayerInstanceModel } from 'src/app/core/players';
+import { Player } from 'src/app/core/players';
 import { MwPlayersService } from 'src/app/features/services';
 
 @Component({
@@ -9,7 +9,7 @@ import { MwPlayersService } from 'src/app/features/services';
 })
 export class MwPlayerResourcesComponent {
 
-  public currentPlayer: PlayerInstanceModel = this.playersService.getCurrentPlayer();
+  public currentPlayer: Player = this.playersService.getCurrentPlayer();
 
   constructor(
     private readonly playersService: MwPlayersService,

--- a/src/app/features/battleground/components/mw-spell-button/mw-spell-button.component.ts
+++ b/src/app/features/battleground/components/mw-spell-button/mw-spell-button.component.ts
@@ -1,7 +1,7 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { Hero } from 'src/app/core/heroes';
-import { PlayerInstanceModel } from 'src/app/core/players';
-import { SpellInstance, SpellActivationType } from 'src/app/core/spells';
+import { Player } from 'src/app/core/players';
+import { Spell, SpellActivationType } from 'src/app/core/spells';
 
 @Component({
   selector: 'mw-spell-button',
@@ -11,7 +11,7 @@ import { SpellInstance, SpellActivationType } from 'src/app/core/spells';
 export class MwSpellButtonComponent {
 
   @Input()
-  public spell!: SpellInstance;
+  public spell!: Spell;
 
   @Input()
   public onCooldown = false;
@@ -23,13 +23,13 @@ export class MwSpellButtonComponent {
   public isActive = false;
 
   @Input()
-  public player!: PlayerInstanceModel;
+  public player!: Player;
 
   @Input()
   public hero!: Hero;
 
   @Output()
-  public clicked = new EventEmitter<SpellInstance>();
+  public clicked = new EventEmitter<Spell>();
 
   public activationTypes = SpellActivationType;
 

--- a/src/app/features/battleground/components/mw-unit-group-card/mw-unit-group-card.component.ts
+++ b/src/app/features/battleground/components/mw-unit-group-card/mw-unit-group-card.component.ts
@@ -2,9 +2,9 @@ import { Component, ElementRef, EventEmitter, forwardRef, Input, OnDestroy, OnIn
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { GroupModifiersChanged, GroupSpellsChanged, HoverTypeEnum, PlayerHoversGroupCard } from 'src/app/core/events';
-import { PlayerModel } from 'src/app/core/players';
-import { SpellActivationType, SpellInstance } from 'src/app/core/spells';
-import { UnitGroupInstModel } from 'src/app/core/unit-types';
+import { Player } from 'src/app/core/players';
+import { SpellActivationType, Spell } from 'src/app/core/spells';
+import { UnitGroup } from 'src/app/core/unit-types';
 import { BattleStateService, MwPlayersService, MwUnitGroupsService, MwUnitGroupStateService, UIModsModel } from 'src/app/features/services';
 import { HintAttachment } from 'src/app/features/shared/components';
 import { PROVIDE_UI_UNIT_GROUP, UIUnitProvider } from 'src/app/features/shared/directives';
@@ -21,10 +21,10 @@ import { StoreClient } from 'src/app/store';
 export class MwUnitGroupCardComponent extends StoreClient() implements UIUnitProvider, OnInit, OnDestroy {
 
   @Input()
-  public unitGroup!: UnitGroupInstModel;
+  public unitGroup!: UnitGroup;
 
   @Input()
-  public playerInfo!: PlayerModel;
+  public playerInfo!: Player;
 
   @Input()
   public side: 'left' | 'right' = 'left';
@@ -38,7 +38,7 @@ export class MwUnitGroupCardComponent extends StoreClient() implements UIUnitPro
   public isEnemyCard!: boolean;
 
   // public potentialUnitCountLoss: number = 0;
-  public attackingUnitGroup!: UnitGroupInstModel;
+  public attackingUnitGroup!: UnitGroup;
 
   public canCurrentPlayerAttack: boolean = false;
   public isGroupMelee: boolean = false;
@@ -46,8 +46,8 @@ export class MwUnitGroupCardComponent extends StoreClient() implements UIUnitPro
 
   public initialCount: number = 0;
 
-  public spells: SpellInstance[] = [];
-  public effects: SpellInstance[] = [];
+  public spells: Spell[] = [];
+  public effects: Spell[] = [];
 
   public spellsHintsPosition!: HintAttachment;
 
@@ -144,7 +144,7 @@ export class MwUnitGroupCardComponent extends StoreClient() implements UIUnitPro
     }
   }
 
-  public getUnitGroup(): UnitGroupInstModel {
+  public getUnitGroup(): UnitGroup {
     return this.unitGroup;
   }
 

--- a/src/app/features/battleground/components/mw-unit-groups-list/mw-unit-groups-list.component.html
+++ b/src/app/features/battleground/components/mw-unit-groups-list/mw-unit-groups-list.component.html
@@ -1,7 +1,7 @@
 <div class="list">
   <div *ngFor="let group of unitGroups"
        class="group"
-       [style.background]="group.ownerPlayerRef?.color">
+       [style.background]="group.ownerPlayerRef.color">
     <div>{{group.type.name}}</div>
     <div>{{group.count}}</div>
   </div>

--- a/src/app/features/battleground/components/mw-unit-groups-list/mw-unit-groups-list.component.ts
+++ b/src/app/features/battleground/components/mw-unit-groups-list/mw-unit-groups-list.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core';
-import { UnitGroupModel } from 'src/app/core/unit-types';
+import { UnitGroup } from 'src/app/core/unit-types';
 
 @Component({
   selector: 'mw-unit-groups-list',
@@ -7,7 +7,7 @@ import { UnitGroupModel } from 'src/app/core/unit-types';
   styleUrls: ['./mw-unit-groups-list.component.scss']
 })
 export class MwUnitGroupsListComponent {
-  @Input() public unitGroups!: UnitGroupModel[];
+  @Input() public unitGroups!: UnitGroup[];
 
   constructor() { }
 }

--- a/src/app/features/battleground/components/popups/item-reward-popup/item-reward-popup.component.ts
+++ b/src/app/features/battleground/components/popups/item-reward-popup/item-reward-popup.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { ItemObject } from 'src/app/core/items';
+import { Item } from 'src/app/core/items';
 import { ItemReward } from 'src/app/core/structures';
 import { StructItemRewardPopup } from 'src/app/core/ui';
 import { MwItemsService, MwPlayersService } from 'src/app/features/services';
@@ -12,9 +12,9 @@ import { BasicPopup } from 'src/app/features/shared/components';
 })
 export class ItemRewardPopupComponent extends BasicPopup<StructItemRewardPopup> implements OnInit {
 
-  public itemGroups!: ItemObject[][];
+  public itemGroups!: Item[][];
 
-  public selectedGroup!: ItemObject[];
+  public selectedGroup!: Item[];
 
   constructor(
     private itemsService: MwItemsService,
@@ -32,7 +32,7 @@ export class ItemRewardPopupComponent extends BasicPopup<StructItemRewardPopup> 
     });
   }
 
-  public setSelectedGroup(group: ItemObject[]): void {
+  public setSelectedGroup(group: Item[]): void {
     this.selectedGroup = group;
   }
 

--- a/src/app/features/battleground/components/popups/item-reward-popup/item-reward-popup.component.ts
+++ b/src/app/features/battleground/components/popups/item-reward-popup/item-reward-popup.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { ItemInstanceModel } from 'src/app/core/items';
+import { ItemObject } from 'src/app/core/items';
 import { ItemReward } from 'src/app/core/structures';
 import { StructItemRewardPopup } from 'src/app/core/ui';
 import { MwItemsService, MwPlayersService } from 'src/app/features/services';
@@ -12,9 +12,9 @@ import { BasicPopup } from 'src/app/features/shared/components';
 })
 export class ItemRewardPopupComponent extends BasicPopup<StructItemRewardPopup> implements OnInit {
 
-  public itemGroups!: ItemInstanceModel[][];
+  public itemGroups!: ItemObject[][];
 
-  public selectedGroup!: ItemInstanceModel[];
+  public selectedGroup!: ItemObject[];
 
   constructor(
     private itemsService: MwItemsService,
@@ -32,7 +32,7 @@ export class ItemRewardPopupComponent extends BasicPopup<StructItemRewardPopup> 
     });
   }
 
-  public setSelectedGroup(group: ItemInstanceModel[]): void {
+  public setSelectedGroup(group: ItemObject[]): void {
     this.selectedGroup = group;
   }
 

--- a/src/app/features/battleground/components/popups/pre-fight-popup/pre-fight-popup.component.html
+++ b/src/app/features/battleground/components/popups/pre-fight-popup/pre-fight-popup.component.html
@@ -4,7 +4,7 @@
 </div>
 
 <div>
-  <mw-unit-groups-list [unitGroups]="data.struct.guard.unitGroups" />
+  <mw-unit-groups-list [unitGroups]="data.struct.guard!.unitGroups" />
 </div>
 
 <div>

--- a/src/app/features/battleground/components/popups/pre-fight-popup/pre-fight-popup.component.ts
+++ b/src/app/features/battleground/components/popups/pre-fight-popup/pre-fight-popup.component.ts
@@ -21,7 +21,8 @@ export class PreFightPopupComponent extends BasicPopup<PrefightPopup> implements
   }
 
   public ngOnInit(): void {
-    this.data.struct.guard.unitGroups.forEach((unitGroup) => {
+    // it actually should be here, think about it later.
+    this.data.struct.guard!.unitGroups.forEach((unitGroup) => {
       this.totalExpReward += Math.round(unitGroup.count * unitGroup.type.neutralReward.experience);
       this.totalGoldReward += Math.round(unitGroup.count * unitGroup.type.neutralReward.experience);
     });

--- a/src/app/features/battleground/components/popups/upgrade-reward-popup/upgrade-reward-popup.component.ts
+++ b/src/app/features/battleground/components/popups/upgrade-reward-popup/upgrade-reward-popup.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { ResourcesModel, ResourceType } from 'src/app/core/resources';
 import { HiringRewardModel, UnitUpgradeReward } from 'src/app/core/structures';
 import { UpgradingPopup } from 'src/app/core/ui';
-import { UnitBase, UnitGroupInstModel } from 'src/app/core/unit-types';
+import { UnitBaseType, UnitGroup } from 'src/app/core/unit-types';
 import { MwPlayersService, MwUnitGroupsService } from 'src/app/features/services';
 import { ApiProvider } from 'src/app/features/services/api-provider.service';
 import { BasicPopup } from 'src/app/features/shared/components';
@@ -14,7 +14,7 @@ interface UpgradeModel {
   baseCost: Partial<ResourcesModel>;
   currentCost: Partial<ResourcesModel>;
 
-  originalGroup: UnitGroupInstModel;
+  originalGroup: UnitGroup;
 }
 
 @Component({
@@ -65,7 +65,7 @@ export class UpgradeRewardPopupComponent extends BasicPopup<UpgradingPopup> impl
         return {
           hire: {
             maxCount: unit.count,
-            unitType: unit.type.upgradeDetails?.target as UnitBase,
+            unitType: unit.type.upgradeDetails?.target as UnitBaseType,
           },
           count: 0,
           baseCost: baseCost,

--- a/src/app/features/battleground/components/unit-group-buff/unit-group-buff.component.ts
+++ b/src/app/features/battleground/components/unit-group-buff/unit-group-buff.component.ts
@@ -1,8 +1,8 @@
 import { Component, Input, OnChanges } from '@angular/core';
 import { Icon } from 'src/app/core/assets';
-import { PlayerInstanceModel } from 'src/app/core/players';
-import { SpellInstance, SpellModel } from 'src/app/core/spells';
-import { UnitGroupInstModel } from 'src/app/core/unit-types';
+// import { PlayerInstanceModel } from 'src/app/core/players';
+import { Spell, SpellBaseType } from 'src/app/core/spells';
+import { UnitGroup } from 'src/app/core/unit-types';
 import { TypedChanges } from 'src/app/core/utils';
 import { HintAttachment } from 'src/app/features/shared/components';
 
@@ -14,15 +14,15 @@ import { HintAttachment } from 'src/app/features/shared/components';
 export class UnitGroupBuffComponent implements OnChanges {
 
   @Input()
-  public buff!: SpellInstance;
+  public buff!: Spell;
 
   @Input()
-  public ownerUnit!: UnitGroupInstModel;
+  public ownerUnit!: UnitGroup;
 
   @Input()
   public hintPos: HintAttachment = 'above';
 
-  public baseType!: SpellModel;
+  public baseType!: SpellBaseType;
 
   public icon!: Icon;
 

--- a/src/app/features/battleground/components/unit-group-spell/unit-group-spell.component.ts
+++ b/src/app/features/battleground/components/unit-group-spell/unit-group-spell.component.ts
@@ -1,10 +1,11 @@
 import { Component, Input, OnChanges } from '@angular/core';
 import { Icon } from 'src/app/core/assets';
 import { Hero } from 'src/app/core/heroes';
-import { SpellActivationType, SpellInstance, SpellModel } from 'src/app/core/spells';
-import { UnitGroupInstModel } from 'src/app/core/unit-types';
+import { PlayerState } from 'src/app/core/players';
+import { SpellActivationType, Spell, SpellBaseType } from 'src/app/core/spells';
+import { UnitGroup } from 'src/app/core/unit-types';
 import { TypedChanges } from 'src/app/core/utils';
-import { MwCurrentPlayerStateService, PlayerState } from 'src/app/features/services';
+import { MwCurrentPlayerStateService } from 'src/app/features/services';
 import { HintAttachment } from 'src/app/features/shared/components';
 
 @Component({
@@ -15,7 +16,7 @@ import { HintAttachment } from 'src/app/features/shared/components';
 export class UnitGroupSpellComponent implements OnChanges {
 
   @Input()
-  public currentUnit!: UnitGroupInstModel;
+  public currentUnit!: UnitGroup;
 
   @Input()
   public onCooldown: boolean | undefined = false;
@@ -24,15 +25,15 @@ export class UnitGroupSpellComponent implements OnChanges {
   public hintPos: HintAttachment = 'above';
 
   @Input()
-  public owner!: UnitGroupInstModel;
+  public owner!: UnitGroup;
 
   @Input()
-  public spell!: SpellInstance;
+  public spell!: Spell;
 
   @Input()
   public hero!: Hero;
 
-  public baseType!: SpellModel;
+  public baseType!: SpellBaseType;
 
   public icon!: Icon;
 

--- a/src/app/features/map-structures/components/mw-structures-view/mw-structures-view.component.ts
+++ b/src/app/features/map-structures/components/mw-structures-view/mw-structures-view.component.ts
@@ -1,7 +1,7 @@
 import { AfterViewInit, Component, ElementRef, Renderer2, ViewChild } from '@angular/core';
 import { MapPanCameraCenterTo, PlayerEntersTown, PlayerOpensHeroInfo, StructSelected } from 'src/app/core/events';
-import { ViewStructure } from 'src/app/core/locations';
-import { PlayerInstanceModel } from 'src/app/core/players';
+import { START_LOC_ID, ViewStructure } from 'src/app/core/locations';
+import { Player } from 'src/app/core/players';
 import { MwPlayersService, MwStructuresService } from 'src/app/features/services';
 import { State } from 'src/app/features/services/state.service';
 import { EventsService } from 'src/app/store';
@@ -20,7 +20,7 @@ export class MwStructuresViewComponent implements AfterViewInit {
   @ViewChild('locationsContainer')
   public locationsRef!: ElementRef;
 
-  public player: PlayerInstanceModel;
+  public player: Player;
 
   constructor(
     private readonly playersService: MwPlayersService,
@@ -42,12 +42,12 @@ export class MwStructuresViewComponent implements AfterViewInit {
       return;
     }
 
-    const startingStruct = this.structsService.viewStructures.find(struct => struct.id === '1');
+    const startingStruct = this.structsService.viewStructures.find(struct => struct.id === START_LOC_ID);
 
     if (startingStruct) {
       this.events.dispatch(MapPanCameraCenterTo({ x: startingStruct.x, y: startingStruct.y }));
     } else {
-      console.warn(`[Map View]: Couldn't find location with id "1" to pan camera center on game start`);
+      console.warn(`[Map View]: Couldn't find location with id ${START_LOC_ID} to pan camera center on game start`);
     }
 
     this.state.mapCamera.cameraInitialized = true;

--- a/src/app/features/services/controllers/battle.service.ts
+++ b/src/app/features/services/controllers/battle.service.ts
@@ -1,10 +1,9 @@
 import { Injectable } from '@angular/core';
 import { CleanUpHandlersOnFightEnd, FightEnds, FightNextRoundStarts, FightStarts, GroupDamagedByGroup, GroupDamagedByGroupEvent, GroupDies, GroupSpeedChanged, GroupTakesDamage, GroupTakesDamageEvent, PlayerTurnStartEvent, RoundGroupSpendsTurn, RoundGroupSpendsTurnEvent, RoundGroupTurnEnds, RoundPlayerCountinuesAttacking, RoundPlayerTurnStarts, UnitHealed, UnitHealedEvent } from 'src/app/core/events';
-import { PlayerTypeEnum } from 'src/app/core/players';
-import { NeutralCampStructure } from 'src/app/core/structures';
+import { PlayerState, PlayerTypeEnum } from 'src/app/core/players';
 import { Notify, StoreClient, WireMethod } from 'src/app/store';
 import { BattleStateService } from '../mw-battle-state.service';
-import { MwCurrentPlayerStateService, PlayerState } from '../mw-current-player-state.service';
+import { MwCurrentPlayerStateService } from '../mw-current-player-state.service';
 import { MwPlayersService } from '../mw-players.service';
 import { MwStructuresService } from '../mw-structures.service';
 import { State } from '../state.service';
@@ -85,7 +84,7 @@ export class BattleController extends StoreClient() {
 
   @Notify(GroupDies)
   public checkIfFightEndedOnUnitGroupDeath(): void {
-    const currentStructure = this.strucuresService.currentStruct as NeutralCampStructure;
+    const currentStructure = this.strucuresService.currentStruct;
 
     const currentPlayer = this.playersService.getCurrentPlayer();
 

--- a/src/app/features/services/controllers/game.service.ts
+++ b/src/app/features/services/controllers/game.service.ts
@@ -9,6 +9,7 @@ import { MwHeroesService } from '../mw-heroes.service';
 import { MwPlayersService, PLAYER_IDS } from '../mw-players.service';
 import { MwStructuresService } from '../mw-structures.service';
 import { State } from '../state.service';
+import { UnitGroup } from 'src/app/core/unit-types';
 
 
 @Injectable()
@@ -40,20 +41,16 @@ export class GameController extends StoreClient() {
 
   @Notify(GameCreated)
   public initPlayersOnGameStart(): void {
-    /*
-       For now, I can see some good overall tendency.
+    const mainPlayer = this.players.createPlayer(
+      PLAYER_IDS.Main,
+      this.players.createPlayerWithHero(
+        this.state.createdGame.selectedColor,
+        this.state.createdGame.selectedHero,
+        PlayerTypeEnum.Player,
+      ),
+    );
 
-       There is a global store, source of truth, then there
-       are some services, that interact with it and have some util
-       methods.
-     */
-    const [mainPlayerId, mainPlayer] = this.players.createPlayerEntry(PLAYER_IDS.Main, this.players.createPlayerWithHero(
-      this.state.createdGame.selectedColor,
-      this.state.createdGame.selectedHero,
-      PlayerTypeEnum.Player,
-    ));
-
-    const [neutralPlayerId, neutralPlayer] = this.players.createPlayerEntry(PLAYER_IDS.Neutral, {
+    const neutralPlayer = this.players.createPlayer(PLAYER_IDS.Neutral, {
       color: PLAYER_COLORS.GRAY,
       type: PlayerTypeEnum.AI,
       hero: this.heroesService.createNeutralHero(),
@@ -67,8 +64,8 @@ export class GameController extends StoreClient() {
       players: [mainPlayer, neutralPlayer],
       currentPlayer: mainPlayer,
       playersMap: new Map([
-        [mainPlayerId, mainPlayer],
-        [neutralPlayerId, neutralPlayer],
+        [mainPlayer.id, mainPlayer],
+        [neutralPlayer.id, neutralPlayer],
       ]),
     };
 
@@ -86,7 +83,8 @@ export class GameController extends StoreClient() {
   public initFight(event: NeutralStructParams): void {
     this.state.currentBattleState = {
       currentPlayer: this.state.gameState.currentPlayer,
-      enemyPlayer: event.struct.guard,
+      // player should be defined, but it needs to be revisited later on
+      enemyPlayer: event.struct.guard!,
     };
   }
 

--- a/src/app/features/services/controllers/popups.service.ts
+++ b/src/app/features/services/controllers/popups.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Type } from '@angular/core';
 import { DisplayPlayerRewardAction, DisplayPlayerRewardPopup, DisplayPopup, DisplayReward, FightEnds, FightEndsEvent, NeutralStructParams, OpenSettings, PlayerOpensHeroInfo, ShowGameOverPopup, StructSelected, StructSelectedEvent } from 'src/app/core/events';
-import { NeutralCampStructure, NeutralRewardTypesEnum, NeutralSite, StructureTypeEnum } from 'src/app/core/structures';
+import { NeutralRewardTypesEnum, StructureTypeEnum } from 'src/app/core/structures';
 import { FightEndsPopup, LossModel, PrefightPopup, PreviewPopup, UpgradingPopup } from 'src/app/core/ui';
 import { Notify, StoreClient, WireMethod } from 'src/app/store';
 import { HiringRewardPopupComponent, ItemRewardPopupComponent, PostFightRewardPopupComponent, PreFightPopupComponent, PreviewPopupComponent, ResourcesRewardPopupComponent, ScriptedRewardPopupComponent, UpgradeRewardPopupComponent } from '../../battleground/components';
@@ -63,7 +63,7 @@ export class PopupsController extends StoreClient() {
   public playerSelectsStructure(event: StructSelectedEvent): void {
     if (event.struct.type === StructureTypeEnum.NeutralCamp) {
       const prefightPopup: PrefightPopup = {
-        struct: event.struct as NeutralCampStructure,
+        struct: event.struct,
       };
 
 
@@ -77,7 +77,7 @@ export class PopupsController extends StoreClient() {
     if (event.struct.type === StructureTypeEnum.NeutralSite) {
       if (event.struct.generator.onVisited) {
         const previewPopup: PreviewPopup = {
-          struct: event.struct as NeutralSite,
+          struct: event.struct,
         };
 
         this.events.dispatch(DisplayPopup({
@@ -89,7 +89,7 @@ export class PopupsController extends StoreClient() {
       }
 
       const upgradingPopup: UpgradingPopup = {
-        struct: event.struct as NeutralSite,
+        struct: event.struct,
       };
 
       this.events.dispatch(DisplayPopup({
@@ -106,7 +106,7 @@ export class PopupsController extends StoreClient() {
       isWin: event.win,
       playerLosses: this.getPlayerLosses(this.playersService.getCurrentPlayerId()),
       enemyLosses: this.getPlayerLosses(this.playersService.getEnemyPlayer().id),
-      struct: event.struct as NeutralCampStructure,
+      struct: event.struct,
     };
 
     this.popupService.createPopup({

--- a/src/app/features/services/controllers/structures.service.ts
+++ b/src/app/features/services/controllers/structures.service.ts
@@ -17,9 +17,12 @@ export class StructuresController extends StoreClient() {
 
   @WireMethod(StructCompleted)
   public handleCompletedStructure(event: NeutralStructParams): void {
-    this.structuresService.availableStructuresMap[event.struct.id] = true;
-    this.structuresService.structsMap.get(event.struct.id)!.visited = true;
-    this.structuresService.playerCurrentLocId = event.struct.id;
+    // revisit this, rework structures.
+    const structId = event.struct.id.split(':')[1];
+
+    this.structuresService.availableStructuresMap[structId] = true;
+    this.structuresService.structsMap.get(structId)!.visited = true;
+    this.structuresService.playerCurrentLocId = structId;
     this.structuresService.updateAvailableStructures();
     this.state.currentGame.travelPoints -= defaultTravelPointsCost;
 

--- a/src/app/features/services/controllers/ui.service.ts
+++ b/src/app/features/services/controllers/ui.service.ts
@@ -2,12 +2,13 @@ import { Injectable } from '@angular/core';
 import { FightEnds, GroupAttacked, HoverTypeEnum, PlayerCastsInstantSpell, PlayerClicksAllyGroup, PlayerClicksAllyGroupEvent, PlayerClicksEnemyGroup, PlayerClicksEnemyGroupEvent, PlayerHoversCardEvent, PlayerHoversGroupCard, PlayerTargetsInstantSpellEvent, PlayerTargetsSpell, PlayerTargetsSpellEvent, PlayerTurnStartEvent, RoundPlayerTurnStarts } from 'src/app/core/events';
 import { SpellEvents } from 'src/app/core/spells';
 import { ActionHintTypeEnum, SpellTargetActionHint } from 'src/app/core/ui';
-import { UnitGroupInstModel } from 'src/app/core/unit-types';
+import { UnitGroup } from 'src/app/core/unit-types';
 import { Notify, StoreClient, WireMethod } from 'src/app/store';
 import { ActionHintService } from '../mw-action-hint.service';
 import { MwCardsMappingService } from '../mw-cards-mapping.service';
 import { CombatInteractorService } from '../mw-combat-interactor.service';
-import { MwCurrentPlayerStateService, PlayerState } from '../mw-current-player-state.service';
+import { MwCurrentPlayerStateService } from '../mw-current-player-state.service';
+import { PlayerState } from 'src/app/core/players';
 
 @Injectable()
 export class UiController extends StoreClient() {
@@ -76,7 +77,7 @@ export class UiController extends StoreClient() {
           const spellTargetHint: SpellTargetActionHint = {
             type: ActionHintTypeEnum.OnTargetSpell,
             spell: this.curPlayerState.currentSpell,
-            target: event.hoveredCard as UnitGroupInstModel,
+            target: event.hoveredCard as UnitGroup,
           };
           this.actionHint.hintMessage$.next(spellTargetHint);
         }
@@ -87,7 +88,7 @@ export class UiController extends StoreClient() {
           const spellTargetHint: SpellTargetActionHint = {
             type: ActionHintTypeEnum.OnTargetSpell,
             spell: this.curPlayerState.currentSpell,
-            target: event.hoveredCard as UnitGroupInstModel,
+            target: event.hoveredCard as UnitGroup,
           };
 
           this.actionHint.hintMessage$.next(spellTargetHint);

--- a/src/app/features/services/game-objects-manager.service.ts
+++ b/src/app/features/services/game-objects-manager.service.ts
@@ -1,0 +1,105 @@
+import { Injectable, Type } from '@angular/core';
+import { CONFIG } from 'src/app/core/config';
+import { InitGameObjectApi } from 'src/app/core/events';
+import { CreationParams, GameObject } from 'src/app/core/game-objects';
+import { EventsService } from 'src/app/store';
+
+function createId(categoryId: string, id: string | number): string {
+  return `${categoryId}:${id}`;
+}
+
+interface ObjectsRegistry<T extends GameObject = GameObject> {
+  latestId: 0;
+  objects: Set<T>;
+};
+
+@Injectable({
+  providedIn: 'root',
+})
+export class GameObjectsManager {
+  // I'll keep id allocation per category, it can be changed after if needed
+  private readonly internalRegistries: Map<string, ObjectsRegistry> = new Map();
+
+  private readonly allObjects: Map<string, GameObject> = new Map();
+
+  constructor(private readonly events: EventsService) { }
+
+  createNewGameObject<T extends GameObject>(gameObjectClass: Type<T> & { categoryId: string }, creationParams: CreationParams<T>, id?: string): T {
+    const categoryId = gameObjectClass.categoryId;
+
+    const unitsRegistry = this.getOrCreateCategoryRegistry(categoryId);
+
+    let newObjectId: string;
+
+    if (id) {
+      const targetedId = createId(categoryId, id);
+
+      if (this.allObjects.has(targetedId)) {
+        console.error(`Game object with id '${targetedId}' already exists! New params/old object:`, creationParams, this.allObjects.get(targetedId));
+        throw new Error(`Game object with id '${targetedId}' already exists!`);
+      }
+
+      newObjectId = targetedId;
+    } else {
+      newObjectId = createId(categoryId, unitsRegistry.latestId++);
+    }
+
+    const newGameObject = new gameObjectClass(newObjectId);
+
+    this.events.dispatch(InitGameObjectApi({ gameObject: newGameObject }));
+
+    newGameObject.create(creationParams);
+
+    unitsRegistry.objects.add(newGameObject);
+
+    this.allObjects.set(newObjectId, newGameObject);
+
+    if (CONFIG.logGameObjects) {
+      console.log(newGameObject);
+    }
+
+    return newGameObject;
+  }
+
+  destroyObject(object: GameObject): void {
+    const objectProto = Object.getPrototypeOf(object);
+
+    const objectCategoryId = (objectProto as typeof GameObject).categoryId;
+
+    const categoryRegistry = this.internalRegistries.get(objectCategoryId);
+
+    categoryRegistry?.objects.delete(object);
+
+    this.allObjects.delete(object.id);
+  }
+
+  getObjectId<T extends GameObject>(gameObjectClass: Type<T> & { categoryId: string }, id: string): string {
+    // check if id is already complete
+    const idParts = id.split(':');
+
+    if (idParts.length === 2 && idParts[0] === gameObjectClass.categoryId) {
+      return id;
+    }
+
+    return createId(gameObjectClass.categoryId, id);
+  }
+
+  private getOrCreateCategoryRegistry(categoryId: string): ObjectsRegistry {
+    const category = this.internalRegistries.get(categoryId);
+
+    if (!category) {
+      this.initializeRegistryForCategory(categoryId);
+
+      return this.internalRegistries.get(categoryId)!;
+    }
+
+    return category;
+  }
+
+  private initializeRegistryForCategory(categoryId: string): void {
+    this.internalRegistries.set(categoryId, {
+      latestId: 0,
+      objects: new Set(),
+    });
+  }
+}

--- a/src/app/features/services/mw-cards-mapping.service.ts
+++ b/src/app/features/services/mw-cards-mapping.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { UnitGroupInstModel } from 'src/app/core/unit-types';
+import { UnitGroup } from 'src/app/core/unit-types';
 import { MwUnitGroupCardComponent } from '../battleground/components';
 
 @Injectable({
@@ -7,19 +7,19 @@ import { MwUnitGroupCardComponent } from '../battleground/components';
 })
 export class MwCardsMappingService {
 
-  private mapping: Map<UnitGroupInstModel, MwUnitGroupCardComponent> = new Map();
+  private mapping: Map<UnitGroup, MwUnitGroupCardComponent> = new Map();
 
   constructor() { }
 
-  public register(unitGroup: UnitGroupInstModel, cardRef: MwUnitGroupCardComponent): void {
+  public register(unitGroup: UnitGroup, cardRef: MwUnitGroupCardComponent): void {
     this.mapping.set(unitGroup, cardRef);
   }
 
-  public unregister(unitGroup: UnitGroupInstModel): void {
+  public unregister(unitGroup: UnitGroup): void {
     this.mapping.delete(unitGroup);
   }
 
-  public get(unitGroup: UnitGroupInstModel): MwUnitGroupCardComponent {
+  public get(unitGroup: UnitGroup): MwUnitGroupCardComponent {
     return this.mapping.get(unitGroup) as MwUnitGroupCardComponent;
   }
 }

--- a/src/app/features/services/mw-heroes.service.ts
+++ b/src/app/features/services/mw-heroes.service.ts
@@ -1,10 +1,10 @@
 import { Injectable } from '@angular/core';
 import { Hero, HeroBase } from 'src/app/core/heroes';
-import { createHeroModelBase, EMPTY_RESOURCES } from 'src/app/core/heroes/utils';
-import { InventoryItems } from 'src/app/core/items/inventory';
-import { SpellInstance } from 'src/app/core/spells';
+import { EMPTY_RESOURCES, createHeroModelBase } from 'src/app/core/heroes/utils';
+import { Spell } from 'src/app/core/spells';
 import { heroDescrElem } from 'src/app/core/ui';
 import { MwSpellsService } from './';
+import { GameObjectsManager } from './game-objects-manager.service';
 
 const neutralHeroBase = createHeroModelBase({
   name: 'neutral-hero',
@@ -26,6 +26,7 @@ const neutralHeroBase = createHeroModelBase({
 export class MwHeroesService {
   constructor(
     private spellsService: MwSpellsService,
+    private gameObjectsManager: GameObjectsManager,
   ) { }
 
   public addManaToHero(hero: Hero, mana: number): void {
@@ -35,7 +36,7 @@ export class MwHeroesService {
     heroStats.currentMana = newMana > heroStats.maxMana ? heroStats.maxMana : newMana;
   }
 
-  public addSpellToHero(hero: Hero, spell: SpellInstance): void {
+  public addSpellToHero(hero: Hero, spell: Spell): void {
     hero.spells.push(spell);
   }
 
@@ -44,49 +45,54 @@ export class MwHeroesService {
   }
 
   public createHero(heroBase: HeroBase): Hero {
-    const heroInitState = heroBase.initialState;
-    const heroBaseStats = heroInitState.stats;
+    // const heroInitState = heroBase.initialState;
+    // const heroBaseStats = heroInitState.stats;
 
-    return {
-      experience: 0,
-      freeSkillpoints: 0,
-      items: [],
-      level: 1,
-      mods: [],
-      name: heroBase.name,
-      spells: heroInitState.abilities.map(spell => this.spellsService.createSpellInstance(spell)),
-      stats: {
-        baseAttack: heroBaseStats.baseAttack,
-        bonusAttack: 0,
-        baseDefence: heroBaseStats.baseDefence,
-        bonusDefence: 0,
-        currentMana: heroBaseStats.mana,
-        maxMana: heroBaseStats.mana,
-      },
-      inventory: new InventoryItems(),
-      base: heroBase,
-    };
+    return this.gameObjectsManager.createNewGameObject(Hero, {
+      heroBase,
+    });
+
+    // return {
+    //   experience: 0,
+    //   freeSkillpoints: 0,
+    //   items: [],
+    //   level: 1,
+    //   mods: [],
+    //   name: heroBase.name,
+    //   spells: heroInitState.abilities.map(spell => this.spellsService.createSpellInstance(spell)),
+    //   stats: {
+    //     baseAttack: heroBaseStats.baseAttack,
+    //     bonusAttack: 0,
+    //     baseDefence: heroBaseStats.baseDefence,
+    //     bonusDefence: 0,
+    //     currentMana: heroBaseStats.mana,
+    //     maxMana: heroBaseStats.mana,
+    //   },
+    //   inventory: new InventoryItems(),
+    //   base: heroBase,
+    // };
   }
 
   public createNeutralHero(): Hero {
-    return {
-      name: null,
-      experience: 0,
-      level: 0,
-      stats: {
-        maxMana: 5,
-        currentMana: 1,
-        baseAttack: 0,
-        baseDefence: 0,
-        bonusAttack: 0,
-        bonusDefence: 0,
-      },
-      freeSkillpoints: 0,
-      spells: [],
-      mods: [],
-      inventory: new InventoryItems(),
-      items: [],
-      base: neutralHeroBase,
-    };
+    return this.gameObjectsManager.createNewGameObject(Hero, { heroBase: neutralHeroBase });
+    // return {
+    //   name: null,
+    //   experience: 0,
+    //   level: 0,
+    //   stats: {
+    //     maxMana: 5,
+    //     currentMana: 1,
+    //     baseAttack: 0,
+    //     baseDefence: 0,
+    //     bonusAttack: 0,
+    //     bonusDefence: 0,
+    //   },
+    //   freeSkillpoints: 0,
+    //   spells: [],
+    //   mods: [],
+    //   inventory: new InventoryItems(),
+    //   items: [],
+    //   base: neutralHeroBase,
+    // };
   }
 }

--- a/src/app/features/services/mw-heroes.service.ts
+++ b/src/app/features/services/mw-heroes.service.ts
@@ -45,54 +45,12 @@ export class MwHeroesService {
   }
 
   public createHero(heroBase: HeroBase): Hero {
-    // const heroInitState = heroBase.initialState;
-    // const heroBaseStats = heroInitState.stats;
-
     return this.gameObjectsManager.createNewGameObject(Hero, {
       heroBase,
     });
-
-    // return {
-    //   experience: 0,
-    //   freeSkillpoints: 0,
-    //   items: [],
-    //   level: 1,
-    //   mods: [],
-    //   name: heroBase.name,
-    //   spells: heroInitState.abilities.map(spell => this.spellsService.createSpellInstance(spell)),
-    //   stats: {
-    //     baseAttack: heroBaseStats.baseAttack,
-    //     bonusAttack: 0,
-    //     baseDefence: heroBaseStats.baseDefence,
-    //     bonusDefence: 0,
-    //     currentMana: heroBaseStats.mana,
-    //     maxMana: heroBaseStats.mana,
-    //   },
-    //   inventory: new InventoryItems(),
-    //   base: heroBase,
-    // };
   }
 
   public createNeutralHero(): Hero {
-    return this.gameObjectsManager.createNewGameObject(Hero, { heroBase: neutralHeroBase });
-    // return {
-    //   name: null,
-    //   experience: 0,
-    //   level: 0,
-    //   stats: {
-    //     maxMana: 5,
-    //     currentMana: 1,
-    //     baseAttack: 0,
-    //     baseDefence: 0,
-    //     bonusAttack: 0,
-    //     bonusDefence: 0,
-    //   },
-    //   freeSkillpoints: 0,
-    //   spells: [],
-    //   mods: [],
-    //   inventory: new InventoryItems(),
-    //   items: [],
-    //   base: neutralHeroBase,
-    // };
+    return this.createHero(neutralHeroBase);
   }
 }

--- a/src/app/features/services/mw-heroes.service.ts
+++ b/src/app/features/services/mw-heroes.service.ts
@@ -3,7 +3,6 @@ import { Hero, HeroBase } from 'src/app/core/heroes';
 import { EMPTY_RESOURCES, createHeroModelBase } from 'src/app/core/heroes/utils';
 import { Spell } from 'src/app/core/spells';
 import { heroDescrElem } from 'src/app/core/ui';
-import { MwSpellsService } from './';
 import { GameObjectsManager } from './game-objects-manager.service';
 
 const neutralHeroBase = createHeroModelBase({
@@ -25,7 +24,6 @@ const neutralHeroBase = createHeroModelBase({
 })
 export class MwHeroesService {
   constructor(
-    private spellsService: MwSpellsService,
     private gameObjectsManager: GameObjectsManager,
   ) { }
 

--- a/src/app/features/services/mw-items.service.ts
+++ b/src/app/features/services/mw-items.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Colors } from 'src/app/core/assets';
 import { InitItem } from 'src/app/core/events';
-import { ItemBaseModel, ItemObject } from 'src/app/core/items';
+import { ItemBaseModel, Item } from 'src/app/core/items';
 import { Player } from 'src/app/core/players';
 import { EventData, EventsService } from 'src/app/store';
 import { State } from './state.service';
@@ -22,7 +22,7 @@ export class MwItemsService {
     private gameObjectsManager: GameObjectsManager,
   ) { }
 
-  public createItem<T extends object>(itemBase: ItemBaseModel<T>): ItemObject<T> {
+  public createItem<T extends object>(itemBase: ItemBaseModel<T>): Item<T> {
     const itemIcon = itemBase.icon;
 
     if (!itemIcon.bgClr) {
@@ -33,13 +33,13 @@ export class MwItemsService {
       itemIcon.iconClr = Colors.DefaultItemIconClr;
     }
 
-    return this.gameObjectsManager.createNewGameObject(ItemObject<T>, {
+    return this.gameObjectsManager.createNewGameObject(Item<T>, {
       itemBase: itemBase,
       state: itemBase.defaultState,
     });
   }
 
-  public registerItemsEventHandlers(item: ItemObject, ownerPlayer: Player): void {
+  public registerItemsEventHandlers(item: Item, ownerPlayer: Player): void {
     this.events.dispatch(InitItem({
       item,
       ownerPlayer,
@@ -52,7 +52,7 @@ export class MwItemsService {
   }
 
   public triggerEventForItemHandlers(
-    item: ItemObject,
+    item: Item,
     event: EventData,
   ): void {
     this.state.eventHandlers.items.triggerRefEventHandlers(item, event);

--- a/src/app/features/services/mw-items.service.ts
+++ b/src/app/features/services/mw-items.service.ts
@@ -1,10 +1,11 @@
 import { Injectable } from '@angular/core';
 import { Colors } from 'src/app/core/assets';
 import { InitItem } from 'src/app/core/events';
-import { ItemBaseModel, ItemInstanceModel } from 'src/app/core/items';
-import { PlayerInstanceModel } from 'src/app/core/players';
+import { ItemBaseModel, ItemObject } from 'src/app/core/items';
+import { Player } from 'src/app/core/players';
 import { EventData, EventsService } from 'src/app/store';
 import { State } from './state.service';
+import { GameObjectsManager } from './game-objects-manager.service';
 
 /* Unregister All items and spell handlers when Game was over... */
 /*  And not only when game is over, but also when fight is over/item gets unregistered, something like that */
@@ -18,9 +19,10 @@ export class MwItemsService {
   constructor(
     private events: EventsService,
     private state: State,
+    private gameObjectsManager: GameObjectsManager,
   ) { }
 
-  public createItem<T extends object>(itemBase: ItemBaseModel<T>): ItemInstanceModel {
+  public createItem<T extends object>(itemBase: ItemBaseModel<T>): ItemObject<T> {
     const itemIcon = itemBase.icon;
 
     if (!itemIcon.bgClr) {
@@ -31,14 +33,13 @@ export class MwItemsService {
       itemIcon.iconClr = Colors.DefaultItemIconClr;
     }
 
-    return {
-      baseType: itemBase,
-      currentDescription: '',
+    return this.gameObjectsManager.createNewGameObject(ItemObject<T>, {
+      itemBase: itemBase,
       state: itemBase.defaultState,
-    } as unknown as ItemInstanceModel;
+    });
   }
 
-  public registerItemsEventHandlers(item: ItemInstanceModel, ownerPlayer: PlayerInstanceModel): void {
+  public registerItemsEventHandlers(item: ItemObject, ownerPlayer: Player): void {
     this.events.dispatch(InitItem({
       item,
       ownerPlayer,
@@ -51,7 +52,7 @@ export class MwItemsService {
   }
 
   public triggerEventForItemHandlers(
-    item: ItemInstanceModel,
+    item: ItemObject,
     event: EventData,
   ): void {
     this.state.eventHandlers.items.triggerRefEventHandlers(item, event);

--- a/src/app/features/services/mw-neutral-player.service.ts
+++ b/src/app/features/services/mw-neutral-player.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
-import { PlayerInstanceModel } from 'src/app/core/players';
-import { UnitGroupInstModel } from 'src/app/core/unit-types';
+import { Player } from 'src/app/core/players';
+import { UnitGroup } from 'src/app/core/unit-types';
 import { MwPlayersService, PLAYER_IDS } from './mw-players.service';
 
 @Injectable({
@@ -9,11 +9,11 @@ import { MwPlayersService, PLAYER_IDS } from './mw-players.service';
 export class MwNeutralPlayerService {
   constructor(private readonly playersService: MwPlayersService) { }
 
-  public getPlayerInfo(): PlayerInstanceModel {
+  public getPlayerInfo(): Player {
     return this.playersService.getEnemyPlayer();
   }
 
-  public getUnitGroups(): UnitGroupInstModel[] {
+  public getUnitGroups(): UnitGroup[] {
     return this.playersService.getUnitGroupsOfPlayer(PLAYER_IDS.Neutral);
   }
 }

--- a/src/app/features/services/mw-player-state.service.ts
+++ b/src/app/features/services/mw-player-state.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
-import { PlayerInstanceModel } from 'src/app/core/players';
-import { UnitGroupInstModel } from 'src/app/core/unit-types';
+import { Player } from 'src/app/core/players';
+import { UnitGroup } from 'src/app/core/unit-types';
 import { MwPlayersService, PLAYER_IDS } from './mw-players.service';
 
 @Injectable({
@@ -11,11 +11,11 @@ export class MwPlayerStateService {
     private playersService: MwPlayersService,
   ) { }
 
-  public getPlayerInfo(): PlayerInstanceModel {
+  public getPlayerInfo(): Player {
     return this.playersService.getCurrentPlayer();
   }
 
-  public getUnitGroups(): UnitGroupInstModel[] {
+  public getUnitGroups(): UnitGroup[] {
     return this.playersService.getUnitGroupsOfPlayer(PLAYER_IDS.Main);
   }
 }

--- a/src/app/features/services/mw-players.service.ts
+++ b/src/app/features/services/mw-players.service.ts
@@ -1,39 +1,14 @@
 import { Injectable } from '@angular/core';
 import { PlayerLevelsUp, PlayerReceivesItem, PlayerUnequipsItem } from 'src/app/core/events';
 import { HERO_LEVELS_BREAKPOINTS, HeroBase } from 'src/app/core/heroes';
-import { ItemInstanceModel } from 'src/app/core/items';
-import { PlayerInstanceModel, PlayerModel, PlayerTypeEnum } from 'src/app/core/players';
+import { ItemObject } from 'src/app/core/items';
+import { PlayerCreationModel, Player, PlayerTypeEnum } from 'src/app/core/players';
 import { ResourceType, Resources, ResourcesModel } from 'src/app/core/resources';
-import { CommonUtils, UnitBase, UnitGroupInstModel, UnitGroupModel } from 'src/app/core/unit-types';
+import { CommonUtils, UnitBaseType, UnitGroup } from 'src/app/core/unit-types';
 import { StoreClient } from 'src/app/store';
 import { MwHeroesService, MwUnitGroupsService } from './';
 import { State } from './state.service';
-
-
-// const mainPlayerGroups = GenerationUtils.createRandomArmy({
-//   fraction: HUMANS_FRACTION_UNIT_TYPES,
-//   maxUnitGroups: 3,
-//   minUnitGroups: 1,
-//   units: [
-//     [HF_TYPES_ENUM.Pikemans, 10, 22, 3],
-//     [HF_TYPES_ENUM.Archers, 12, 20, 1],
-//     [HF_TYPES_ENUM.Knights, 5, 9, 1],
-//     [HF_TYPES_ENUM.Cavalry, 3, 5, 1],
-//   ],
-// });
-
-// const neutralGroups = GenerationUtils.createRandomArmy({
-//   fraction: NEUTRAL_FRACTION_UNIT_TYPES,
-//   maxUnitGroups: 5,
-//   minUnitGroups: 2,
-//   units: [
-//     [NEUTRAL_TYPES_ENUM.Gnolls, 10, 40, 3],
-//     // [NEUTRAL_TYPES_ENUM.Gnolls, 10, 15, 3],
-//     [NEUTRAL_TYPES_ENUM.ForestTrolls, 10, 25, 2],
-//     [NEUTRAL_TYPES_ENUM.Thiefs, 12, 37, 2],
-//     [NEUTRAL_TYPES_ENUM.Ghosts, 24, 42, 3],
-//   ],
-// });
+import { GameObjectsManager } from './game-objects-manager.service';
 
 export enum PLAYER_IDS {
   Main = 'main',
@@ -47,51 +22,57 @@ const defaultResources: ResourcesModel = {
   wood: 0,
 }
 
-
 @Injectable({
   providedIn: 'root'
 })
 export class MwPlayersService extends StoreClient() {
 
-  private get playersMap(): Map<string, PlayerInstanceModel> {
+  // theoretically, if objects are being stored in manager, I might access them
+  // from manager.
+  private get playersMap(): Map<string, Player> {
     return this.state.gameState.playersMap;
   };
 
-  private currentPlayerId: string = PLAYER_IDS.Main;
+  private currentPlayerId: string = this.gameObjectsManager.getObjectId(Player, PLAYER_IDS.Main);
 
   constructor(
     private readonly heroesService: MwHeroesService,
     private readonly unitGroups: MwUnitGroupsService,
     private readonly state: State,
+    private readonly gameObjectsManager: GameObjectsManager,
   ) {
     super();
   }
 
-  public getCurrentPlayer(): PlayerInstanceModel {
-    return this.playersMap.get(this.currentPlayerId) as PlayerInstanceModel;
+  public createPlayer(id: string, playerInfo: PlayerCreationModel): Player {
+    return this.gameObjectsManager.createNewGameObject(Player, playerInfo, id);
+  }
+
+  public getCurrentPlayer(): Player {
+    return this.playersMap.get(this.currentPlayerId)!;
   }
 
   public addResourceToPlayer(
-    player: PlayerInstanceModel,
+    player: Player,
     resource: ResourceType,
     amount: number,
   ): void {
     player.resources[resource] += amount;
   }
 
-  public addResourcesToPlayer(player: PlayerInstanceModel, resources: Resources): void {
+  public addResourcesToPlayer(player: Player, resources: Resources): void {
     Object.entries(resources).forEach(([res, count]) => player.resources[res as ResourceType] += count);
   }
 
   public removeResourcesFromPlayer(
-    player: PlayerInstanceModel,
+    player: Player,
     resources: Resources,
   ): void {
     Object.entries(resources).forEach(([res, count]) => player.resources[res as ResourceType] -= count);
   }
 
   public playerHasResources(
-    player: PlayerInstanceModel,
+    player: Player,
     resources: Resources,
   ): boolean {
     const playerResources = player.resources;
@@ -100,7 +81,7 @@ export class MwPlayersService extends StoreClient() {
   }
 
   public getMissingResources(
-    player: PlayerInstanceModel,
+    player: Player,
     resources: Resources,
   ): Resources {
     const playerResources = player.resources;
@@ -120,11 +101,11 @@ export class MwPlayersService extends StoreClient() {
     return this.currentPlayerId;
   }
 
-  public isEnemyUnitGroup(unitGroup: UnitGroupInstModel): boolean {
+  public isEnemyUnitGroup(unitGroup: UnitGroup): boolean {
     return this.getUnitGroupsOfPlayer(this.getEnemyPlayer().id).includes(unitGroup);
   }
 
-  public getPlayerUnitsCountOfType(player: PlayerInstanceModel, unitType: UnitBase): number {
+  public getPlayerUnitsCountOfType(player: Player, unitType: UnitBaseType): number {
     return player.unitGroups.reduce((totalCount, nextUnitGroupType) => totalCount + (nextUnitGroupType.type === unitType ? nextUnitGroupType.count : 0), 0);
   }
 
@@ -146,25 +127,26 @@ export class MwPlayersService extends StoreClient() {
     }
   }
 
-  public getPlayerById(playerId: string): PlayerInstanceModel {
-    return this.playersMap.get(playerId) as PlayerInstanceModel;
+  public getPlayerById(playerId: string): Player {
+    return this.playersMap.get(this.gameObjectsManager.getObjectId(Player, playerId))!;
   }
 
-  public getNeutralPlayer(): PlayerInstanceModel {
-    return this.playersMap.get(PLAYER_IDS.Neutral)!;
+  public getNeutralPlayer(): Player {
+    return this.playersMap.get(this.gameObjectsManager.getObjectId(Player, PLAYER_IDS.Neutral))!;
   }
 
-  public getEnemyPlayer(): PlayerInstanceModel {
+  public getEnemyPlayer(): Player {
     /* Might be changed */
     return this.getNeutralPlayer();
   }
 
-  public getUnitGroupsOfPlayer(playerId: string): UnitGroupInstModel[] {
-    const player = this.playersMap.get(playerId) as PlayerInstanceModel;
-    return player.unitGroups.map((unitGroup: UnitGroupModel) => {
+  public getUnitGroupsOfPlayer(playerId: string): UnitGroup[] {
+    const player = this.playersMap.get(this.gameObjectsManager.getObjectId(Player, playerId))!;
+
+    return player.unitGroups.map((unitGroup: UnitGroup) => {
       unitGroup.ownerPlayerRef = player;
 
-      const unitGroupInstance = unitGroup as UnitGroupInstModel;
+      const unitGroupInstance = unitGroup as UnitGroup;
 
       unitGroupInstance.spells = unitGroupInstance.spells ?? [];
 
@@ -172,7 +154,7 @@ export class MwPlayersService extends StoreClient() {
     })
   }
 
-  public addUnitGroupToTypeStack(player: PlayerModel, unitGroup: UnitGroupModel): void {
+  public addUnitGroupToTypeStack(player: Player, unitGroup: UnitGroup): void {
     const sameTypeStack = player.unitGroups.find(group => group.type === unitGroup.type);
     if (sameTypeStack) {
       sameTypeStack.count += unitGroup.count;
@@ -182,7 +164,7 @@ export class MwPlayersService extends StoreClient() {
   }
 
   /* todo: rework this method later, allow to check several stacks */
-  public removeNUnitsFromGroup(player: PlayerModel, unitGroup: UnitGroupModel, count: number): void {
+  public removeNUnitsFromGroup(player: Player, unitGroup: UnitGroup, count: number): void {
     unitGroup.count -= count;
 
     if (unitGroup.count <= 0) {
@@ -190,45 +172,29 @@ export class MwPlayersService extends StoreClient() {
     }
   }
 
-  public addManaToPlayer(player: PlayerInstanceModel, mana: number): void {
+  public addManaToPlayer(player: Player, mana: number): void {
     player.hero.stats.currentMana += mana;
   }
 
-  public addItemToPlayer(player: PlayerInstanceModel, item: ItemInstanceModel): void {
+  public addItemToPlayer(player: Player, item: ItemObject): void {
     this.events.dispatch(PlayerReceivesItem({ player, item }));
   }
 
-  public removeItemFromPlayer(player: PlayerInstanceModel, item: ItemInstanceModel): void {
+  public removeItemFromPlayer(player: Player, item: ItemObject): void {
     this.events.dispatch(PlayerUnequipsItem({ player, item }));
-  }
-
-
-  public createPlayerEntry(id: string, playerInfo: PlayerModel): [string, PlayerInstanceModel] {
-    return [id, this.createPlayer(id, playerInfo)];
   }
 
   public createPlayerWithHero(
     color: string,
     hero: HeroBase,
     type: PlayerTypeEnum,
-  ): PlayerModel {
-    const player = {
+  ): PlayerCreationModel {
+    return {
       color,
       hero: this.heroesService.createHero(hero),
       resources: hero.initialState.resources,
       type,
       unitGroups: this.unitGroups.createUnitGroupFromGenModel(hero.initialState.army[0]),
     };
-
-    return player;
-  }
-
-  private createPlayer(id: string, playerInfo: PlayerModel): PlayerInstanceModel {
-    const player: PlayerInstanceModel = {
-      id,
-      ...playerInfo,
-    };
-
-    return player;
   }
 }

--- a/src/app/features/services/mw-players.service.ts
+++ b/src/app/features/services/mw-players.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { PlayerLevelsUp, PlayerReceivesItem, PlayerUnequipsItem } from 'src/app/core/events';
 import { HERO_LEVELS_BREAKPOINTS, HeroBase } from 'src/app/core/heroes';
-import { ItemObject } from 'src/app/core/items';
+import { Item } from 'src/app/core/items';
 import { PlayerCreationModel, Player, PlayerTypeEnum } from 'src/app/core/players';
 import { ResourceType, Resources, ResourcesModel } from 'src/app/core/resources';
 import { CommonUtils, UnitBaseType, UnitGroup } from 'src/app/core/unit-types';
@@ -176,11 +176,11 @@ export class MwPlayersService extends StoreClient() {
     player.hero.stats.currentMana += mana;
   }
 
-  public addItemToPlayer(player: Player, item: ItemObject): void {
+  public addItemToPlayer(player: Player, item: Item): void {
     this.events.dispatch(PlayerReceivesItem({ player, item }));
   }
 
-  public removeItemFromPlayer(player: Player, item: ItemObject): void {
+  public removeItemFromPlayer(player: Player, item: Item): void {
     this.events.dispatch(PlayerUnequipsItem({ player, item }));
   }
 

--- a/src/app/features/services/mw-spells.service.ts
+++ b/src/app/features/services/mw-spells.service.ts
@@ -2,8 +2,9 @@ import { Injectable } from '@angular/core';
 import { SpellCreationOptions } from 'src/app/core/api/combat-api';
 import { Colors } from 'src/app/core/assets';
 import { Modifiers } from 'src/app/core/modifiers';
-import { SpellInstance, SpellModel } from 'src/app/core/spells';
-import { UnitGroupInstModel } from 'src/app/core/unit-types';
+import { Spell, SpellBaseType } from 'src/app/core/spells';
+import { UnitGroup } from 'src/app/core/unit-types';
+import { GameObjectsManager } from './game-objects-manager.service';
 
 
 @Injectable({
@@ -11,12 +12,14 @@ import { UnitGroupInstModel } from 'src/app/core/unit-types';
 })
 export class MwSpellsService {
 
-  constructor() { }
+  constructor(
+    private gameObjectManager: GameObjectsManager,
+  ) { }
 
   public createSpellInstance<T>(
-    spell: SpellModel<T>,
+    spell: SpellBaseType<T>,
     options: SpellCreationOptions<T> = {},
-  ): SpellInstance<T> {
+  ): Spell<T> {
     const initialLevel: number = options.initialLevel ?? 1;
     const spellIcon = spell.icon;
 
@@ -28,17 +31,11 @@ export class MwSpellsService {
       spellIcon.iconClr = Colors.DefaultItemIconClr;
     }
 
-    const spellInstance: SpellInstance<T> = {
-      currentLevel: initialLevel,
-      currentManaCost: 0,
-      description: spell.description ?? '',
-      name: spell.type.spellInfo.name,
-      baseType: spell,
-      state: options.state ?? null,
-      sourceInfo: {},
-    };
-
-    spellInstance.currentManaCost = spell.type.spellConfig.getManaCost(spellInstance);
+    const spellInstance = this.gameObjectManager.createNewGameObject(Spell<T>, {
+      spellBaseType: spell,
+      initialLevel: initialLevel,
+      state: options.state,
+    });
 
     return spellInstance;
   }
@@ -47,7 +44,7 @@ export class MwSpellsService {
     return modifiers;
   }
 
-  public canSpellBeCastOnUnit(spell: SpellInstance, unitGroup: UnitGroupInstModel, isEnemy: boolean): boolean {
+  public canSpellBeCastOnUnit(spell: Spell, unitGroup: UnitGroup, isEnemy: boolean): boolean {
     const spellConfig = spell.baseType.type.spellConfig;
 
     const canActivateFn = spellConfig.targetCastConfig?.canActivate;

--- a/src/app/features/services/mw-unit-group-state.service.ts
+++ b/src/app/features/services/mw-unit-group-state.service.ts
@@ -1,11 +1,12 @@
 import { Injectable } from '@angular/core';
-import { UnitGroupModel } from 'src/app/core/unit-types';
+// import { UnitGroupUnstModel } from 'src/app/core/unit-types';
 import { CommonUtils } from 'src/app/core/unit-types/utils';
 import { MwUnitGroupsService } from './mw-unit-groups.service';
 import { Modifiers } from 'src/app/core/modifiers';
+import { UnitGroup } from 'src/app/core/unit-types';
 
 export interface DamageInfo {
-  attacker: UnitGroupModel;
+  attacker: UnitGroup;
 
   attackingUnitsCount: number;
 
@@ -20,7 +21,7 @@ export interface DamageInfo {
 }
 
 export interface DetailedDamageInfo extends DamageInfo {
-  attacked: UnitGroupModel;
+  attacked: UnitGroup;
 
   enemyCanCounterattack: boolean;
   minUnitCountLoss: number;
@@ -51,7 +52,7 @@ export class MwUnitGroupStateService {
     private units: MwUnitGroupsService,
   ) { }
 
-  public getTailUnitHealth(unitGroup: UnitGroupModel): number {
+  public getTailUnitHealth(unitGroup: UnitGroup): number {
     const { tailUnitHp } = unitGroup;
 
     if (tailUnitHp === 0) {
@@ -63,11 +64,11 @@ export class MwUnitGroupStateService {
     return tailUnitHp;
   }
 
-  public getUnitGroupTotalHp(unitGroup: UnitGroupModel): number {
+  public getUnitGroupTotalHp(unitGroup: UnitGroup): number {
     return (unitGroup.count - 1) * unitGroup.type.baseStats.health + this.getTailUnitHealth(unitGroup);
   }
 
-  public getUnitGroupDamage(unitGroup: UnitGroupModel, attackSuperiority: number = 0): DamageInfo {
+  public getUnitGroupDamage(unitGroup: UnitGroup, attackSuperiority: number = 0): DamageInfo {
     const groupBaseStats = unitGroup.type.baseStats;
     const groupDamageInfo = groupBaseStats.damageInfo;
     const unitsCount = unitGroup.count;
@@ -97,8 +98,8 @@ export class MwUnitGroupStateService {
   }
 
   public getDetailedAttackInfo(
-    attackingGroup: UnitGroupModel,
-    attackedGroup: UnitGroupModel,
+    attackingGroup: UnitGroup,
+    attackedGroup: UnitGroup,
     attackingMods: Modifiers[] = [],
     attackedMods: Modifiers[] = [],
   ): DetailedDamageInfo {
@@ -171,7 +172,7 @@ export class MwUnitGroupStateService {
 
       It becomes 0 only when the full group is defeated.
   */
-  public getFinalDamageInfo(target: UnitGroupModel, damage: number): FinalDamageInfo {
+  public getFinalDamageInfo(target: UnitGroup, damage: number): FinalDamageInfo {
     const attackedGroup = target;
     const targetBaseStats = attackedGroup.type.baseStats;
 
@@ -219,7 +220,7 @@ export class MwUnitGroupStateService {
     };
   }
 
-  public dealPureDamageToUnitGroup(target: UnitGroupModel, damage: number): FinalDamageInfo {
+  public dealPureDamageToUnitGroup(target: UnitGroup, damage: number): FinalDamageInfo {
     const finalDamageInfo = this.getFinalDamageInfo(target, damage);
     target.count -= finalDamageInfo.finalUnitLoss;
     target.tailUnitHp = finalDamageInfo.tailHpLeft;
@@ -232,11 +233,11 @@ export class MwUnitGroupStateService {
     return unitCountLoss > groupCount ? groupCount : unitCountLoss;
   }
 
-  public canGroupCounterattack(group: UnitGroupModel): boolean {
+  public canGroupCounterattack(group: UnitGroup): boolean {
     return !!group.type.defaultModifiers?.counterattacks;
   }
 
-  public isUnitGroupRanged(group: UnitGroupModel): boolean {
+  public isUnitGroupRanged(group: UnitGroup): boolean {
     return !!group.type.defaultModifiers?.isRanged;
   }
 

--- a/src/app/features/services/state.service.ts
+++ b/src/app/features/services/state.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Fraction } from 'src/app/core/fractions';
 import { HeroBase } from 'src/app/core/heroes';
-import { ItemObject } from 'src/app/core/items';
+import { Item } from 'src/app/core/items';
 import { defaultTravelPointsPerDay } from 'src/app/core/locations';
 import { LevelMap } from 'src/app/core/maps';
 import { ModsRefsGroup } from 'src/app/core/modifiers';
@@ -78,10 +78,10 @@ export class State {
 
   public eventHandlers: {
     spells: RefEventTriggersRegistry<Spell>,
-    items: RefEventTriggersRegistry<ItemObject>,
+    items: RefEventTriggersRegistry<Item>,
   } = {
       spells: new RefEventTriggersRegistry<Spell>(),
-      items: new RefEventTriggersRegistry<ItemObject>(),
+      items: new RefEventTriggersRegistry<Item>(),
     };
 
   public unitsAppliedModifiers: Map<UnitGroup, ModsRefsGroup> = new Map();

--- a/src/app/features/services/state.service.ts
+++ b/src/app/features/services/state.service.ts
@@ -1,14 +1,16 @@
 import { Injectable } from '@angular/core';
 import { Fraction } from 'src/app/core/fractions';
 import { HeroBase } from 'src/app/core/heroes';
-import { ItemInstanceModel } from 'src/app/core/items';
+import { ItemObject } from 'src/app/core/items';
 import { defaultTravelPointsPerDay } from 'src/app/core/locations';
 import { LevelMap } from 'src/app/core/maps';
-import { PlayerInstanceModel } from 'src/app/core/players';
-import { SpellInstance } from 'src/app/core/spells';
+import { ModsRefsGroup } from 'src/app/core/modifiers';
+import { Player } from 'src/app/core/players';
+import { Spell } from 'src/app/core/spells';
 import { Town } from 'src/app/core/towns';
 import { RefEventTriggersRegistry } from 'src/app/core/triggers';
 import { UnitsOrientation } from 'src/app/core/ui';
+import { UnitGroup } from 'src/app/core/unit-types';
 
 /*
   I think I want to have state parts as separated features, maybe don't want to have all
@@ -52,9 +54,9 @@ export class State {
     };
 
   public gameState!: {
-    players: PlayerInstanceModel[];
-    currentPlayer: PlayerInstanceModel;
-    playersMap: Map<string, PlayerInstanceModel>;
+    players: Player[];
+    currentPlayer: Player;
+    playersMap: Map<string, Player>;
   };
 
   public mapsState!: {
@@ -70,15 +72,17 @@ export class State {
 
   /* State for when battle starts */
   public currentBattleState!: {
-    currentPlayer: PlayerInstanceModel;
-    enemyPlayer: PlayerInstanceModel;
+    currentPlayer: Player;
+    enemyPlayer: Player;
   };
 
   public eventHandlers: {
-    spells: RefEventTriggersRegistry<SpellInstance>,
-    items: RefEventTriggersRegistry<ItemInstanceModel>,
+    spells: RefEventTriggersRegistry<Spell>,
+    items: RefEventTriggersRegistry<ItemObject>,
   } = {
-      spells: new RefEventTriggersRegistry<SpellInstance>(),
-      items: new RefEventTriggersRegistry<ItemInstanceModel>(),
+      spells: new RefEventTriggersRegistry<Spell>(),
+      items: new RefEventTriggersRegistry<ItemObject>(),
     };
+
+  public unitsAppliedModifiers: Map<UnitGroup, ModsRefsGroup> = new Map();
 }

--- a/src/app/features/services/tests/common.ts
+++ b/src/app/features/services/tests/common.ts
@@ -1,11 +1,11 @@
-import { TaltirHero } from 'src/app/core/heroes/humans';
-import { InventoryItems } from 'src/app/core/items';
-import { PlayerInstanceModel, PlayerTypeEnum } from 'src/app/core/players';
-import { UnitBase, UnitGroupInstModel } from 'src/app/core/unit-types';
+import { Player, PlayerTypeEnum } from 'src/app/core/players';
+import { UnitBaseType, UnitGroup } from 'src/app/core/unit-types';
 import { MwUnitGroupStateService } from '../mw-unit-group-state.service';
 import { MwUnitGroupsService } from '../mw-unit-groups.service';
+import { Hero, createHeroModelBase } from 'src/app/core/heroes';
+import { DescriptionElementType } from 'src/app/core/ui';
 
-export const testUnitTypeNoArmorNoRating: UnitBase = {
+export const testUnitTypeNoArmorNoRating: UnitBaseType = {
   name: 'Test Unit (No Armor/Attack Rating)',
   type: 'test-plain-stats',
   baseRequirements: {},
@@ -33,49 +33,48 @@ export const testUnitTypeNoArmorNoRating: UnitBase = {
   upgraded: false,
 };
 
-export const player: PlayerInstanceModel = {
-  color: '',
-  hero: {
-    base: TaltirHero,
-    experience: 0,
-    freeSkillpoints: 1,
-    inventory: new InventoryItems(),
+const hero = new Hero('0');
+
+hero.create({
+  heroBase: createHeroModelBase({
+    abilities: [],
+    army: [],
+    generalDescription: { type: DescriptionElementType.FreeHtml },
     items: [],
-    level: 0,
-    mods: [],
     name: '',
-    spells: [],
+    resources: {
+      gems: 0,
+      gold: 0,
+      redCrystals: 0,
+      wood: 0,
+    },
     stats: {
       baseAttack: 0,
       baseDefence: 0,
-      bonusAttack: 0,
-      bonusDefence: 0,
-      currentMana: 0,
-      maxMana: 0,
+      mana: 0,
     },
-  },
-  id: '1',
-  resources: {
-    gems: 0,
-    gold: 0,
-    redCrystals: 0,
-    wood: 0,
-  },
+  }),
+});
+
+export const player = new Player('0');
+
+player.create({
+  color: '',
+  hero: hero,
+  resources: { gems: 0, gold: 0, redCrystals: 0, wood: 0 },
   type: PlayerTypeEnum.Player,
   unitGroups: [],
-};
+});
 
 export const getCommonFunctions = (services: () => { unitsService: MwUnitGroupsService, unitState: MwUnitGroupStateService }) => {
-
-  // const { unitState, unitsService } = services();
 
   const createTestUnitGroup = (count: number) => services().unitsService.createUnitGroup(
     testUnitTypeNoArmorNoRating,
     { count },
     player
-  ) as UnitGroupInstModel;
+  ) as UnitGroup;
 
-  const getDamageDetails = (attacker: UnitGroupInstModel, attacked: UnitGroupInstModel) => {
+  const getDamageDetails = (attacker: UnitGroup, attacked: UnitGroup) => {
     const damageDetails = services().unitState.getDetailedAttackInfo(attacker, attacked, [], []);
 
     const damageFinalDetails = services().unitState.getFinalDamageInfoFromDamageDetailedInfo(damageDetails);

--- a/src/app/features/services/tests/unit-damage-tests.spec.ts
+++ b/src/app/features/services/tests/unit-damage-tests.spec.ts
@@ -1,8 +1,8 @@
 import { TestBed } from '@angular/core/testing';
 import { TaltirHero } from 'src/app/core/heroes/humans';
 import { InventoryItems } from 'src/app/core/items';
-import { PlayerInstanceModel, PlayerTypeEnum } from 'src/app/core/players';
-import { UnitBase, UnitGroupInstModel } from 'src/app/core/unit-types';
+import { Player, PlayerTypeEnum } from 'src/app/core/players';
+import { UnitBaseType, UnitGroup } from 'src/app/core/unit-types';
 import { CombatInteractorService } from '../mw-combat-interactor.service';
 import { MwPlayersService } from '../mw-players.service';
 import { MwUnitGroupStateService } from '../mw-unit-group-state.service';

--- a/src/app/features/shared/components/item-description/item-description.component.ts
+++ b/src/app/features/shared/components/item-description/item-description.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
-import { ItemObject } from 'src/app/core/items';
+import { Item } from 'src/app/core/items';
 import { DescriptionElement } from 'src/app/core/ui/descriptions';
 
 @Component({
@@ -11,7 +11,7 @@ import { DescriptionElement } from 'src/app/core/ui/descriptions';
 export class ItemDescriptionComponent implements OnInit {
 
   @Input()
-  public item!: ItemObject;
+  public item!: Item;
 
   public descriptions!: DescriptionElement[];
 

--- a/src/app/features/shared/components/item-description/item-description.component.ts
+++ b/src/app/features/shared/components/item-description/item-description.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
-import { ItemInstanceModel } from 'src/app/core/items';
+import { ItemObject } from 'src/app/core/items';
 import { DescriptionElement } from 'src/app/core/ui/descriptions';
 
 @Component({
@@ -11,7 +11,7 @@ import { DescriptionElement } from 'src/app/core/ui/descriptions';
 export class ItemDescriptionComponent implements OnInit {
 
   @Input()
-  public item!: ItemInstanceModel;
+  public item!: ItemObject;
 
   public descriptions!: DescriptionElement[];
 

--- a/src/app/features/shared/components/mw-experience-bar/mw-experience-bar.component.ts
+++ b/src/app/features/shared/components/mw-experience-bar/mw-experience-bar.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { HERO_LEVELS_BREAKPOINTS } from 'src/app/core/heroes';
-import { PlayerInstanceModel } from 'src/app/core/players';
+import { Player } from 'src/app/core/players';
 import { MwPlayersService } from 'src/app/features/services';
 
 @Component({
@@ -10,7 +10,7 @@ import { MwPlayersService } from 'src/app/features/services';
 })
 export class MwExperienceBarComponent {
 
-  public currentPlayer: PlayerInstanceModel = this.players.getCurrentPlayer();
+  public currentPlayer: Player = this.players.getCurrentPlayer();
   public xpToNextLevel: number;
 
   constructor(

--- a/src/app/features/shared/components/mw-player-info-panel/mw-player-info-panel.component.ts
+++ b/src/app/features/shared/components/mw-player-info-panel/mw-player-info-panel.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { PlayerOpensHeroInfo } from 'src/app/core/events';
-import { PlayerInstanceModel } from 'src/app/core/players';
+import { Player } from 'src/app/core/players';
 import { MwPlayersService } from 'src/app/features/services';
 import { State } from 'src/app/features/services/state.service';
 import { EventsService } from 'src/app/store';
@@ -12,7 +12,7 @@ import { EventsService } from 'src/app/store';
 })
 export class MwPlayerInfoPanelComponent {
 
-  public player: PlayerInstanceModel = this.players.getCurrentPlayer();
+  public player: Player = this.players.getCurrentPlayer();
 
   constructor(
     private players: MwPlayersService,

--- a/src/app/features/shared/components/spell-description/spell-description.component.ts
+++ b/src/app/features/shared/components/spell-description/spell-description.component.ts
@@ -1,9 +1,9 @@
 import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
 import { Hero } from 'src/app/core/heroes';
-import { PlayerInstanceModel } from 'src/app/core/players';
-import { SpellInstance } from 'src/app/core/spells';
+import { Player } from 'src/app/core/players';
+import { Spell } from 'src/app/core/spells';
 import { DescriptionElement } from 'src/app/core/ui/descriptions';
-import { UnitGroupInstModel } from 'src/app/core/unit-types';
+import { UnitGroup } from 'src/app/core/unit-types';
 
 @Component({
   selector: 'mw-spell-description',
@@ -14,16 +14,16 @@ import { UnitGroupInstModel } from 'src/app/core/unit-types';
 export class SpellDescriptionComponent implements OnInit {
 
   @Input()
-  public spell!: SpellInstance;
+  public spell!: Spell;
 
   @Input()
   public hero!: Hero;
 
   @Input()
-  public player!: PlayerInstanceModel;
+  public player!: Player;
 
   @Input()
-  public ownerUnit?: UnitGroupInstModel;
+  public ownerUnit?: UnitGroup;
 
   public descriptions!: DescriptionElement[];
 

--- a/src/app/features/shared/components/vfx-layer/vfx-layer.component.ts
+++ b/src/app/features/shared/components/vfx-layer/vfx-layer.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectorRef, Component, OnInit, Renderer2, TemplateRef, ViewChild
 import { combineLatest, fromEvent } from 'rxjs';
 import { take } from 'rxjs/operators';
 import { CustomAnimationData, Effect, EffectInstRef, EffectOptions, EffectPosition, EffectType, VfxElemEffect } from 'src/app/core/api/vfx-api';
-import { UnitGroupInstModel } from 'src/app/core/unit-types';
+import { UnitGroup } from 'src/app/core/unit-types';
 import { FloatingMessageAnimation } from 'src/app/core/vfx';
 import { MwCardsMappingService } from 'src/app/features/services';
 import { VfxElementComponent } from '../vfx-element/vfx-element.component';
@@ -58,7 +58,7 @@ export class VfxLayerComponent implements OnInit {
   }
 
   public createVfxForUnitGroup(
-    unitGroup: UnitGroupInstModel,
+    unitGroup: UnitGroup,
     effect: Effect<EffectType>,
     options: EffectOptions
   ): void {
@@ -82,7 +82,7 @@ export class VfxLayerComponent implements OnInit {
 
   /* in theory, createVfxForUnitGroup can be reused */
   public createFloatingMessageForUnitGroup(
-    unitGroup: UnitGroupInstModel,
+    unitGroup: UnitGroup,
     data: CustomAnimationData,
     options: EffectOptions = {},
   ): void {

--- a/src/app/features/shared/components/vfx-layer/vfx.service.ts
+++ b/src/app/features/shared/components/vfx-layer/vfx.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { EffectOptions, Effect, CustomizableAnimationData } from 'src/app/core/api/vfx-api';
-import { UnitGroupInstModel } from 'src/app/core/unit-types/types';
+import { UnitGroup } from 'src/app/core/unit-types/types';
 import type { VfxLayerComponent } from './vfx-layer.component';
 
 
@@ -39,7 +39,7 @@ export class VfxService {
   }
 
   public createVfxForUnitGroup(
-    unitGroup: UnitGroupInstModel,
+    unitGroup: UnitGroup,
     effect: Effect,
     options: EffectOptions = {},
   ): void {
@@ -50,7 +50,7 @@ export class VfxService {
   }
 
   public createFloatingMessageForUnitGroup(
-    unitGroup: UnitGroupInstModel,
+    unitGroup: UnitGroup,
     data: CustomizableAnimationData,
     options: EffectOptions = {},
   ): void {

--- a/src/app/features/shared/directives/mw-spell-target.directive.ts
+++ b/src/app/features/shared/directives/mw-spell-target.directive.ts
@@ -1,6 +1,6 @@
 import { Directive, HostListener, Input, OnInit } from '@angular/core';
 import { HoverTypeEnum, PlayerClicksAllyGroup, PlayerClicksEnemyGroup, PlayerHoversGroupCard } from 'src/app/core/events';
-import { UnitGroupInstModel } from 'src/app/core/unit-types';
+import { UnitGroup } from 'src/app/core/unit-types';
 import { EventsService } from 'src/app/store';
 import { BattleStateService, MwCurrentPlayerStateService, MwPlayersService } from '../../services';
 
@@ -12,7 +12,7 @@ import { BattleStateService, MwCurrentPlayerStateService, MwPlayersService } fro
 })
 export class MwSpellTargetDirective implements OnInit {
 
-  @Input() public spellTargetUnitGroup!: UnitGroupInstModel;
+  @Input() public spellTargetUnitGroup!: UnitGroup;
 
   private isEnemyCard: boolean = false;
 

--- a/src/app/features/shared/directives/mw-unit-events-cursor.directive.ts
+++ b/src/app/features/shared/directives/mw-unit-events-cursor.directive.ts
@@ -1,13 +1,14 @@
 import { Directive, ElementRef, Inject, InjectionToken, NgZone, OnInit, Renderer2 } from '@angular/core';
 import { takeUntil } from 'rxjs/operators';
-import { UnitGroupInstModel } from 'src/app/core/unit-types';
+import { UnitGroup } from 'src/app/core/unit-types';
 import { SpellCastCursorAnimation, StaticCursorAnimation } from 'src/app/core/vfx';
-import { MwCurrentPlayerStateService, MwPlayersService, MwSpellsService, PlayerState } from '../../services';
+import { MwCurrentPlayerStateService, MwPlayersService, MwSpellsService } from '../../services';
 import { CursorService } from '../components/custom-cursor/cursor.service';
 import { AnimatedCursor, MwCustomCursorDirective } from './mw-custom-cursor.directive';
+import { PlayerState } from 'src/app/core/players';
 
 export interface UIUnitProvider {
-  getUnitGroup(): UnitGroupInstModel;
+  getUnitGroup(): UnitGroup;
 }
 
 export const PROVIDE_UI_UNIT_GROUP: InjectionToken<string> = new InjectionToken('UI element unit group provider');
@@ -17,7 +18,7 @@ export const PROVIDE_UI_UNIT_GROUP: InjectionToken<string> = new InjectionToken(
   selector: '[mwUnitEventsCursor]'
 })
 export class MwUnitEventsCursorDirective extends MwCustomCursorDirective implements OnInit {
-  private unitGroup!: UnitGroupInstModel;
+  private unitGroup!: UnitGroup;
 
   constructor(
     vfx: CursorService,

--- a/src/app/features/towns/components/build-popup/build-popup.component.ts
+++ b/src/app/features/towns/components/build-popup/build-popup.component.ts
@@ -31,7 +31,6 @@ export class BuildPopupComponent extends BasicPopup<{ building: Building, target
     this.cost = formattedResources(buildingCost);
 
     this.missingCostMap = this.players.getMissingResources(this.players.getCurrentPlayer(), buildingCost);
-    // this.missingCost = formattedResources(this.missingCostMap);
 
     this.canBuild = this.players.playerHasResources(
       this.players.getCurrentPlayer(),

--- a/src/app/features/towns/components/hiring-popup/hiring-popup.component.ts
+++ b/src/app/features/towns/components/hiring-popup/hiring-popup.component.ts
@@ -1,8 +1,7 @@
 import { Component, OnInit } from '@angular/core';
-import { Fractions } from 'src/app/core/fractions';
-import { Resources, ResourcesModel, ResourceType } from 'src/app/core/resources';
+import { ResourceType, Resources, ResourcesModel } from 'src/app/core/resources';
 import { BuidlingBase, Building, HiringActivity, HiringDetails, Town } from 'src/app/core/towns';
-import { UnitBase } from 'src/app/core/unit-types';
+import { UnitBaseType } from 'src/app/core/unit-types';
 import { MwPlayersService, MwUnitGroupsService } from 'src/app/features/services';
 import { BasicPopup, PopupService } from 'src/app/features/shared/components';
 import { BuildPopupComponent } from '../build-popup/build-popup.component';
@@ -14,7 +13,7 @@ interface HiringPopupData {
 }
 
 interface UnitHiringModel {
-  unitType: UnitBase;
+  unitType: UnitBaseType;
   maxCount: number;
 }
 
@@ -48,7 +47,7 @@ export class HiringPopupComponent extends BasicPopup<HiringPopupData> implements
 
   public currentMode: HireMode = 'hire';
 
-  public unitType: UnitBase;
+  public unitType: UnitBaseType;
 
   public currentBuilding: BuidlingBase;
 

--- a/src/app/notes/__game_objects.ts
+++ b/src/app/notes/__game_objects.ts
@@ -1,0 +1,14 @@
+/*
+  Game objects will have an id, it will be possible for me to keep track of
+    existing objects. Also, objects can be easily enhanced, with
+    things like cleanups, methods, events, etc.
+
+  So, this allows objects to be tracked. Second thing, I could use
+    my event system here, these GameObjects might listen to it and emit events
+    on their own. Third thing is that theoretically, events can be targeted at
+    specific entity.
+
+  Current Game Objects:
+
+  UnitGroup, Item, Hero, Player, Spell, Structure
+*/

--- a/src/app/notes/__globals.ts
+++ b/src/app/notes/__globals.ts
@@ -1,4 +1,37 @@
 /*
+  Coding.
+    Console commands: I might add some events that can be interpreted
+    as commands in console.
+
+    Event types: I can try to extract a type from events group,
+    and refer the type of Events by this util type.
+
+  Some elements of balancing.
+    Some strong units, like Archers, might have a delayed upgrade, or
+    even conditional upgrade. For instance, Archers cannot not be upgraded
+    into Crossbowmen until the Town Hall is level 3 or 4. It could also
+    be hero-dependent. Some heroes might get an early tech for Archers.
+
+    But there might also be some interesting choice making. For instance,
+    though tech for Archers is delayed in town, there might be a map
+    structure that allows to promote Archers to Crossbowmen. It will
+    take player to make decisions, if he wants to promote his Archers
+    earlier, or he might wanna just save some money on costly tech
+    for Archers.
+
+    Potentially, structures outside of town may promote units using other
+    resources and minimal unit number, like you can promote 10 Archers
+    into 10 Crossbowmen using 3 Iron and 3 Wood.
+
+    In some rare cases, units might have no upgrade available in town.
+
+    But as well, such strong units can be moderated with cost. You could
+    spend money you saved from not buying Archers on something else.
+    So, considerable price can ignite choice making.
+
+    Also, some low-level units might give/receive bonuses when army
+    is stacked with some other units of tier below 3 or 4.
+
   Features.
     Maybe there can be some feature class that can be used to describe
     features in the state. It can be configured in any way, also


### PR DESCRIPTION
Major overhaul, introducing new concept: `GameObject`, as well as new global service, `GameObjectsManager`. It is responsible for creation and accessing main game objects (Players, Heroes, UnitGroups, Items, Spells, Structures, etc.). Game objects must extend `GameObject` class, must define a static `categoryId`, they are controlling the way they are being constructed by defining `create` method. Game objects also have an access to game api, and eventually might start to listen/dispatch events from within themselves. They might also expose some reactive properties like Subjects or Signals.