### PR TITLE
Change card positioning to position instead of translate, disable gold bonus from defeated guards

### DIFF
--- a/src/app/features/battleground/components/mw-unit-group-card/mw-unit-group-card.component.scss
+++ b/src/app/features/battleground/components/mw-unit-group-card/mw-unit-group-card.component.scss
@@ -20,6 +20,8 @@
   display: flex;
   position: relative;
   transition: 0.5s;
+  left: 0;
+  right: 0;
 }
 
 /* brightness can be used to make element darker */
@@ -195,32 +197,32 @@ $inactive-offset: 32px;
 :host-context(.vertical) .card-top {
   &.active {
     &.card-left {
-      translate: $active-offset 0;
+      left: $active-offset;
     }
 
     &.card-right {
-      translate: -$active-offset 0;
+      right: $active-offset;
     }
   }
 
   &.inactive {
     &.card-left {
-      translate: -$inactive-offset 0;
+      left: -$inactive-offset;
     }
 
     &.card-right {
-      translate: $inactive-offset 0;
+      right: -$inactive-offset;
     }
   }
 
 
   &.defeated {
     &.card-left {
-      translate: -$inactive-offset 0;
+      left: -$inactive-offset;
     }
 
     &.card-right {
-      translate: $inactive-offset 0;
+      right: $inactive-offset;
     }
   }
 }

--- a/src/app/features/battleground/components/popups/post-fight-reward-popup/post-fight-reward-popup.component.html
+++ b/src/app/features/battleground/components/popups/post-fight-reward-popup/post-fight-reward-popup.component.html
@@ -24,7 +24,7 @@
   </div>
 
   <div>
-    <div>Gold: +{{totalGoldReward}}</div>
+    <!-- <div>Gold: +{{totalGoldReward}}</div> -->
     <div>Experience: +{{totalExperienceReward}}</div>
   </div>
 

--- a/src/app/features/battleground/components/popups/post-fight-reward-popup/post-fight-reward-popup.component.ts
+++ b/src/app/features/battleground/components/popups/post-fight-reward-popup/post-fight-reward-popup.component.ts
@@ -25,7 +25,8 @@ export class PostFightRewardPopupComponent extends BasicPopup<FightEndsPopup> im
 
   ngOnInit(): void {
     this.data.enemyLosses.forEach(group => {
-      this.totalGoldReward += Math.round(group.count * group.type.neutralReward.gold);
+      // maybe this can be a good thing.
+      // this.totalGoldReward += Math.round(group.count * group.type.neutralReward.gold);
       this.totalExperienceReward += Math.round(group.count * group.type.neutralReward.experience);
     });
   }

--- a/src/app/features/battleground/components/popups/pre-fight-popup/pre-fight-popup.component.html
+++ b/src/app/features/battleground/components/popups/pre-fight-popup/pre-fight-popup.component.html
@@ -12,7 +12,7 @@
 </div>
 
 <div>
-  <div>Gold: {{totalGoldReward}}</div>
+  <!-- <div>Gold: {{totalGoldReward}}</div> -->
   <div>Experience: {{totalExpReward}}</div>
 </div>
 

--- a/src/app/features/battleground/components/popups/pre-fight-popup/pre-fight-popup.component.ts
+++ b/src/app/features/battleground/components/popups/pre-fight-popup/pre-fight-popup.component.ts
@@ -23,8 +23,8 @@ export class PreFightPopupComponent extends BasicPopup<StructPopupData> implemen
   public ngOnInit(): void {
     // can be a service/api method
     this.data.struct.guard?.forEach((unitGroup) => {
+      // this.totalGoldReward += Math.round(unitGroup.count * unitGroup.type.neutralReward.gold);
       this.totalExpReward += Math.round(unitGroup.count * unitGroup.type.neutralReward.experience);
-      this.totalGoldReward += Math.round(unitGroup.count * unitGroup.type.neutralReward.gold);
     });
   }
 


### PR DESCRIPTION
Changing `translate` to `position + left/right` could potentially increase animation performance for unit cards